### PR TITLE
set up CI and replication config tests

### DIFF
--- a/.github/mongonet/create-replica-set.js
+++ b/.github/mongonet/create-replica-set.js
@@ -1,0 +1,22 @@
+db = connect('mongodb://localhost/admin');
+db.runCommand({'replSetInitiate': {
+    "_id": "test-set",
+    "members": [
+        {
+            "_id": 1,
+            "host": "mongo-1:27017",
+            "priority": 2
+        },
+        {
+            "_id": 2,
+            "host": "mongo-2:27017",
+            "priority": 1
+        },
+        {
+            "_id": 3,
+            "host": "mongo-3:27017",
+            "priority": 0,
+            "arbiterOnly": true
+        }
+    ]
+}});

--- a/.github/mongonet/create-replica-set.js
+++ b/.github/mongonet/create-replica-set.js
@@ -1,4 +1,4 @@
-db = connect('mongodb://localhost/admin');
+db = connect('mongodb://mongo-1:27017/admin');
 db.runCommand({'replSetInitiate': {
     "_id": "test-set",
     "version": 1,

--- a/.github/mongonet/create-replica-set.js
+++ b/.github/mongonet/create-replica-set.js
@@ -1,6 +1,7 @@
 db = connect('mongodb://localhost/admin');
 db.runCommand({'replSetInitiate': {
     "_id": "test-set",
+    "version": 1,
     "members": [
         {
             "_id": 1,

--- a/.github/mongonet/create-users.js
+++ b/.github/mongonet/create-users.js
@@ -1,0 +1,2 @@
+db = connect('mongodb://localhost/admin');
+db.createUser({user: "root", pwd: "80085", roles: ["root"]});

--- a/.github/mongonet/docker-compose.yml
+++ b/.github/mongonet/docker-compose.yml
@@ -1,0 +1,68 @@
+version: "3.9"
+services:
+    # a mock standalone deployment
+    mongo-single:
+        image: mongo:latest
+        hostname: mongo-single
+        networks:
+            - mongonet
+        ports:
+            - 30000:27017
+        restart: always
+        volumes:
+            - ./create-users.js:/docker-entrypoint-initdb.d/create-users.js
+            - ./mongod.conf:/etc/mongod.conf
+            - ./data/db:/data/db
+        command: mongod --config /etc/mongod.conf
+
+    # a mock replica set deployment
+    # mongo-1:
+    #     image: mongo:latest
+    #     hostname: mongo-1
+    #     networks:
+    #         - mongonet
+    #     ports:
+    #         - 30001:27017
+    #     restart: always
+    #     volumes:
+    #         - ./test-set.conf:/etc/mongod.conf
+    #         - ./data-1/db:/data/db
+    #     command: mongod --config /etc/mongod.conf
+    # mongo-2:
+    #     image: mongo:latest
+    #     hostname: mongo-2
+    #     networks:
+    #         - mongonet
+    #     ports:
+    #         - 30002:27017
+    #     restart: always
+    #     volumes:
+    #         - ./test-set.conf:/etc/mongod.conf
+    #         - ./data-2/db:/data/db
+    #     command: mongod --config /etc/mongod.conf
+    # mongo-3:
+    #     image: mongo:latest
+    #     hostname: mongo-3
+    #     networks:
+    #         - mongonet
+    #     ports:
+    #         - 30003:27017
+    #     restart: always
+    #     volumes:
+    #         - ./test-set.conf:/etc/mongod.conf
+    #         - ./data-3/db:/data/db
+    #     command: mongod --config /etc/mongod.conf
+
+    # mongo-init:
+    #     image: mongo:latest
+    #     depends_on:
+    #         - mongo-single
+    #     networks:
+    #         - mongonet
+    #     volumes:
+    #         - ./create-users.js:/create-users.js
+    #     command: mongosh --file /create-users.js
+
+networks: 
+    mongonet:
+        name: mongonet

--- a/.github/mongonet/docker-compose.yml
+++ b/.github/mongonet/docker-compose.yml
@@ -15,53 +15,50 @@ services:
             - ./data/db:/data/db
         command: mongod --config /etc/mongod.conf
 
-    # a mock replica set deployment
-    # mongo-1:
-    #     image: mongo:latest
-    #     hostname: mongo-1
-    #     networks:
-    #         - mongonet
-    #     ports:
-    #         - 30001:27017
-    #     restart: always
-    #     volumes:
-    #         - ./test-set.conf:/etc/mongod.conf
-    #         - ./data-1/db:/data/db
-    #     command: mongod --config /etc/mongod.conf
-    # mongo-2:
-    #     image: mongo:latest
-    #     hostname: mongo-2
-    #     networks:
-    #         - mongonet
-    #     ports:
-    #         - 30002:27017
-    #     restart: always
-    #     volumes:
-    #         - ./test-set.conf:/etc/mongod.conf
-    #         - ./data-2/db:/data/db
-    #     command: mongod --config /etc/mongod.conf
-    # mongo-3:
-    #     image: mongo:latest
-    #     hostname: mongo-3
-    #     networks:
-    #         - mongonet
-    #     ports:
-    #         - 30003:27017
-    #     restart: always
-    #     volumes:
-    #         - ./test-set.conf:/etc/mongod.conf
-    #         - ./data-3/db:/data/db
-    #     command: mongod --config /etc/mongod.conf
-
-    # mongo-init:
-    #     image: mongo:latest
-    #     depends_on:
-    #         - mongo-single
-    #     networks:
-    #         - mongonet
-    #     volumes:
-    #         - ./create-users.js:/create-users.js
-    #     command: mongosh --file /create-users.js
+    # a mock replica set deployment. *every* member runs the init script,
+    # the last one to do so will know about all the other members.
+    mongo-1:
+        image: mongo:latest
+        hostname: mongo-1
+        networks:
+            - mongonet
+        ports:
+            - 30001:27017
+        restart: always
+        volumes:
+            - ./create-replica-set.js:/docker-entrypoint-initdb.d/create-replica-set.js
+            - ./test-set.conf:/etc/mongod.conf
+            - ./data-1/db:/data/db
+        command: mongod --config /etc/mongod.conf
+        depends_on:
+            - mongo-2
+            - mongo-3
+    mongo-2:
+        image: mongo:latest
+        hostname: mongo-2
+        networks:
+            - mongonet
+        ports:
+            - 30002:27017
+        restart: always
+        volumes:
+            - ./create-replica-set.js:/docker-entrypoint-initdb.d/create-replica-set.js
+            - ./test-set.conf:/etc/mongod.conf
+            - ./data-2/db:/data/db
+        command: mongod --config /etc/mongod.conf
+    mongo-3:
+        image: mongo:latest
+        hostname: mongo-3
+        networks:
+            - mongonet
+        ports:
+            - 30003:27017
+        restart: always
+        volumes:
+            - ./create-replica-set.js:/docker-entrypoint-initdb.d/create-replica-set.js
+            - ./test-set.conf:/etc/mongod.conf
+            - ./data-3/db:/data/db
+        command: mongod --config /etc/mongod.conf
 
 networks: 
     mongonet:

--- a/.github/mongonet/docker-compose.yml
+++ b/.github/mongonet/docker-compose.yml
@@ -26,13 +26,11 @@ services:
             - 30001:27017
         restart: always
         volumes:
-            - ./create-replica-set.js:/docker-entrypoint-initdb.d/create-replica-set.js
+        # cannot put this in docker-entrypoint-initdb.d, it does not work
+            - ./create-replica-set.js:/create-replica-set.js
             - ./test-set.conf:/etc/mongod.conf
             - ./data-1/db:/data/db
         command: mongod --config /etc/mongod.conf
-        depends_on:
-            - mongo-2
-            - mongo-3
     mongo-2:
         image: mongo:latest
         hostname: mongo-2
@@ -42,7 +40,7 @@ services:
             - 30002:27017
         restart: always
         volumes:
-            - ./create-replica-set.js:/docker-entrypoint-initdb.d/create-replica-set.js
+            - ./create-replica-set.js:/create-replica-set.js
             - ./test-set.conf:/etc/mongod.conf
             - ./data-2/db:/data/db
         command: mongod --config /etc/mongod.conf
@@ -55,7 +53,7 @@ services:
             - 30003:27017
         restart: always
         volumes:
-            - ./create-replica-set.js:/docker-entrypoint-initdb.d/create-replica-set.js
+            - ./create-replica-set.js:/create-replica-set.js
             - ./test-set.conf:/etc/mongod.conf
             - ./data-3/db:/data/db
         command: mongod --config /etc/mongod.conf

--- a/.github/mongonet/mongod.conf
+++ b/.github/mongonet/mongod.conf
@@ -1,0 +1,10 @@
+security:
+    authorization: enabled
+net:
+    port: 27017
+    bindIp: 0.0.0.0
+    bindIpAll: true
+systemLog:
+    component:
+        network:
+            verbosity: 5

--- a/.github/mongonet/test-set.conf
+++ b/.github/mongonet/test-set.conf
@@ -1,0 +1,10 @@
+replication:
+    replSetName: test-set
+net:
+    port: 27017
+    bindIp: 0.0.0.0
+    bindIpAll: true
+systemLog:
+    component:
+        network:
+            verbosity: 5

--- a/.github/run-pipeline
+++ b/.github/run-pipeline
@@ -2,4 +2,6 @@
 
 swift --version
 swift build -c release --target MongoSessions
+swift build -c release --target MongoDB
 swift run   -c release          MongoSessionsTests
+swift run   -c release          MongoDBTests

--- a/.github/run-pipeline
+++ b/.github/run-pipeline
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+swift --version
+swift build -c release --target MongoSessions
+swift run   -c release          MongoSessionsTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
                     tar -xzf swift-${{ matrix.swift.toolchain }}.tar.gz -C $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }} --strip 1
                     echo "$GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}/usr/bin" >> $GITHUB_PATH
             
-            -   name: set up mock deployments 
+            -   name: set up mock deployments
                 run: |
                     docker compose -f .github/mongonet/docker-compose.yml up -d
             

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,10 @@ jobs:
             -   name: set up mock deployments
                 run: |
                     docker compose -f .github/mongonet/docker-compose.yml up -d
+                    nc -zv localhost 30000
+                    nc -zv localhost 30001
+                    nc -zv localhost 30002
+                    nc -zv localhost 30003
             
             -   name: build
                 run: |
@@ -67,5 +71,5 @@ jobs:
                     
             -   name: test
                 run: |
-                    swift run -c release MongoSessionsTests localhost:30000
                     swift run -c release MongoSessionsTests localhost:30001 localhost:30002 localhost:30003
+                    swift run -c release MongoSessionsTests localhost:30000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
         steps:
             -   name: checkout repository
-            -   uses: actions/checkout@v3
+                uses: actions/checkout@v3
             
             -   name: set up mock deployments
                 run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,8 @@ jobs:
             
             -   name: initialize replica set
                 run: |
-                    docker exec -t mongonet-mongo-1-1 /bin/mongosh --file /create-replica-set.js
+                    timeout 15s bash -c \
+                    'until docker exec -t mongonet-mongo-1-1 /bin/mongosh --file /create-replica-set.js; do sleep 1; done'
             
             -   name: build and test
                 run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,15 +55,17 @@ jobs:
                     mkdir -p $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}
                     tar -xzf swift-${{ matrix.swift.toolchain }}.tar.gz -C $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }} --strip 1
                     echo "$GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}/usr/bin" >> $GITHUB_PATH
+            
+            -   name: set up mock deployments
+                run: |
+                    docker compose -f .github/mongonet/docker-compose.yml up -d
+            
             -   name: build
                 run: |
                     swift --version
                     swift build -c release --target MongoSessions
-            
-            -   name: set up mongo (single)
-                run: |
-                    docker compose -f .github/mongonet/docker-compose.yml up -d
                     
             -   name: test
                 run: |
                     swift run -c release MongoSessionsTests localhost:30000
+                    swift run -c release MongoSessionsTests localhost:30001 localhost:30002 localhost:30003

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,11 @@ jobs:
                 swift: 
                     -   toolchain:  DEVELOPMENT-SNAPSHOT-2022-12-17-a
                         branch:     development
-                    -   toolchain:  5.7.2-RELEASE
-                        branch:     swift-5.7.2-release
+                    # -   toolchain:  5.7.2-RELEASE
+                    #     branch:     swift-5.7.2-release
 
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
             
             -   name: cache swift toolchains
                 uses: actions/cache@v2
@@ -61,12 +61,9 @@ jobs:
                     swift build -c release --target MongoSessions
             
             -   name: set up mongo (single)
-                uses: supercharge/mongodb-github-action@1.8.0
-                with:
-                    mongodb-version: 6.0
-                    mongodb-username: root
-                    mongodb-password: password
+                run: |
+                    docker compose -f .github/mongonet/docker-compose.yml up -d
                     
             -   name: test
                 run: |
-                    swift run -c release MongoSessionsTests localhost
+                    swift run -c release MongoSessionsTests localhost:30000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
             matrix:
                 image: 
                 -   nightly-amazonlinux2
+                -   nightly
 
         steps:
             -   name: checkout repository
@@ -26,7 +27,7 @@ jobs:
             
             -   name: initialize replica set
                 run: |
-                    timeout 15s bash -c \
+                    timeout 30s bash -c \
                     'until docker exec -t mongonet-mongo-1-1 /bin/mongosh --file /create-replica-set.js; do sleep 1; done'
             
             -   name: build and test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
                     tar -xzf swift-${{ matrix.swift.toolchain }}.tar.gz -C $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }} --strip 1
                     echo "$GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}/usr/bin" >> $GITHUB_PATH
             
-            -   name: set up mock deployments
+            -   name: set up mock deployments 
                 run: |
                     docker compose -f .github/mongonet/docker-compose.yml up -d
             

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,4 @@ jobs:
                         -v $PWD:/swift-mongodb \
                         -w /swift-mongodb \
                         swiftlang/swift:${{ matrix.image }} \
-                    swift --version &&
-                    swift build -c release --target MongoSessions &&
-                    swift run   -c release          MongoSessionsTests
+                    .github/run-pipeline

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,68 +8,33 @@ on:
 
 jobs:
     linux:
-        runs-on: ${{ matrix.os.runner }}
-        name: ${{ matrix.os.runner }} (${{ matrix.swift.toolchain }})
+        runs-on: ubuntu-22.04
+        name: ${{ matrix.image }}
 
         strategy:
             matrix:
-                os: 
-                    -   runner: ubuntu-22.04
-                        prefix: ubuntu2204
-                        suffix: ubuntu22.04
-                    -   runner: ubuntu-20.04
-                        prefix: ubuntu2004
-                        suffix: ubuntu20.04
-                swift: 
-                    -   toolchain:  DEVELOPMENT-SNAPSHOT-2022-12-17-a
-                        branch:     development
-                    # -   toolchain:  5.7.2-RELEASE
-                    #     branch:     swift-5.7.2-release
+                image: 
+                -   nightly-main-amazonlinux2
 
         steps:
+            -   name: checkout repository
             -   uses: actions/checkout@v3
-            
-            -   name: cache swift toolchains
-                uses: actions/cache@v2
-                with:
-                    path: swift-${{ matrix.swift.toolchain }}.tar.gz
-                    key: ${{ matrix.os.runner }}:swift:${{ matrix.swift.toolchain }}
-                    
-            -   name: cache status
-                id:   cache_status
-                uses: andstor/file-existence-action@v1
-                with:
-                    files: swift-${{ matrix.swift.toolchain }}.tar.gz
-            
-            -   name: download swift toolchain 
-                if: steps.cache_status.outputs.files_exists == 'false'
-                run:   "curl https://download.swift.org/\
-                        ${{ matrix.swift.branch }}/\
-                        ${{ matrix.os.prefix }}/\
-                        swift-${{ matrix.swift.toolchain }}/\
-                        swift-${{ matrix.swift.toolchain }}-${{ matrix.os.suffix }}.tar.gz \
-                        --output swift-${{ matrix.swift.toolchain }}.tar.gz"
-            
-            -   name: set up swift
-                run: |
-                    mkdir -p $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}
-                    tar -xzf swift-${{ matrix.swift.toolchain }}.tar.gz -C $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }} --strip 1
-                    echo "$GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}/usr/bin" >> $GITHUB_PATH
             
             -   name: set up mock deployments
                 run: |
                     docker compose -f .github/mongonet/docker-compose.yml up -d
-                    nc -zv localhost 30000
-                    nc -zv localhost 30001
-                    nc -zv localhost 30002
-                    nc -zv localhost 30003
             
-            -   name: build
+            -   name: initialize replica set
                 run: |
-                    swift --version
-                    swift build -c release --target MongoSessions
-                    
-            -   name: test
+                    docker exec -t mongonet-mongo-1-1 /bin/mongosh --file /create-replica-set.js
+            
+            -   name: build and test
                 run: |
-                    swift run -c release MongoSessionsTests localhost:30001 localhost:30002 localhost:30003
-                    swift run -c release MongoSessionsTests localhost:30000
+                    docker run -t --rm --network=mongonet \
+                        --name mongonet-environment \
+                        -v $PWD:/swift-mongodb \
+                        -w /swift-mongodb \
+                        swiftlang/swift:${{ matrix.image }} \
+                    swift --version &&
+                    swift build -c release --target MongoSessions &&
+                    swift run   -c release          MongoSessionsTests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,72 @@
+name: build
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    linux:
+        runs-on: ${{ matrix.os.runner }}
+        name: ${{ matrix.os.runner }} (${{ matrix.swift.toolchain }})
+
+        strategy:
+            matrix:
+                os: 
+                    -   runner: ubuntu-22.04
+                        prefix: ubuntu2204
+                        suffix: ubuntu22.04
+                    -   runner: ubuntu-20.04
+                        prefix: ubuntu2004
+                        suffix: ubuntu20.04
+                swift: 
+                    -   toolchain:  DEVELOPMENT-SNAPSHOT-2022-12-17-a
+                        branch:     development
+                    -   toolchain:  5.7.2-RELEASE
+                        branch:     swift-5.7.2-release
+
+        steps:
+            -   uses: actions/checkout@v2
+            
+            -   name: cache swift toolchains
+                uses: actions/cache@v2
+                with:
+                    path: swift-${{ matrix.swift.toolchain }}.tar.gz
+                    key: ${{ matrix.os.runner }}:swift:${{ matrix.swift.toolchain }}
+                    
+            -   name: cache status
+                id:   cache_status
+                uses: andstor/file-existence-action@v1
+                with:
+                    files: swift-${{ matrix.swift.toolchain }}.tar.gz
+            
+            -   name: download swift toolchain 
+                if: steps.cache_status.outputs.files_exists == 'false'
+                run:   "curl https://download.swift.org/\
+                        ${{ matrix.swift.branch }}/\
+                        ${{ matrix.os.prefix }}/\
+                        swift-${{ matrix.swift.toolchain }}/\
+                        swift-${{ matrix.swift.toolchain }}-${{ matrix.os.suffix }}.tar.gz \
+                        --output swift-${{ matrix.swift.toolchain }}.tar.gz"
+            
+            -   name: set up swift
+                run: |
+                    mkdir -p $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}
+                    tar -xzf swift-${{ matrix.swift.toolchain }}.tar.gz -C $GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }} --strip 1
+                    echo "$GITHUB_WORKSPACE/swift-${{ matrix.swift.toolchain }}/usr/bin" >> $GITHUB_PATH
+            -   name: build
+                run: |
+                    swift --version
+                    swift build -c release --target MongoSessions
+            
+            -   name: set up mongo (single)
+                uses: supercharge/mongodb-github-action@1.8.0
+                with:
+                    mongodb-version: 6.0
+                    mongodb-username: root
+                    mongodb-password: password
+                    
+            -   name: test
+                run: |
+                    swift run -c release MongoSessionsTests localhost

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             matrix:
                 image: 
-                -   nightly-main-amazonlinux2
+                -   nightly-amazonlinux2
 
         steps:
             -   name: checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build
+.github/mongonet/data*

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
-        "version" : "1.0.2"
+        "revision" : "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
+        "version" : "1.0.3"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e855380cb5234e96b760d93e0bfdc403e381e928",
-        "version" : "2.45.0"
+        "revision" : "7e3b50b38e4e66f31db6cf4a784c6af148bac846",
+        "version" : "2.46.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
-        "version" : "1.0.3"
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,11 +30,11 @@ let package:Package = .init(name: "swift-mongodb",
         .package(url: "https://github.com/kelvin13/swift-package-factory.git",
             revision: "swift-DEVELOPMENT-SNAPSHOT-2022-12-17-a"),
         
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMinor(from: "2.45.0")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMinor(from: "2.46.0")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMinor(from: "2.23.0")),
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.3"),
     ],
-    targets: 
+    targets:
     [
         .target(name: "TraceableErrors"),
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
   
 ***`mongodb`***<br>`0.1.0`
 
+[![ci status](https://github.com/kelvin13/swift-mongodb/actions/workflows/build.yml/badge.svg)](https://github.com/kelvin13/swift-mongodb/actions/workflows/build.yml)
+
 [![swift package index versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fkelvin13%2Fswift-mongodb%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/kelvin13/swift-mongodb)
 [![swift package index platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fkelvin13%2Fswift-mongodb%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/kelvin13/swift-mongodb)
 

--- a/Sources/MongoDB/Commands/ListDatabases/Mongo.ListDatabases.swift
+++ b/Sources/MongoDB/Commands/ListDatabases/Mongo.ListDatabases.swift
@@ -42,8 +42,9 @@ extension Mongo.ListDatabases:MongoCommand
         bson["filter", elide: true] = self.filter
     }
 
-    public static
-    func decode<Bytes>(reply bson:BSON.Dictionary<Bytes>) throws -> Response
+    @inlinable public static
+    func decode(
+        reply bson:BSON.Dictionary<some RandomAccessCollection<UInt8>>) throws -> Response
     {
         (
             totalSize: try bson["totalSize"].decode(to: Int.self),

--- a/Sources/MongoSessions/Commands/Hello/Mongo.Hello.Response.swift
+++ b/Sources/MongoSessions/Commands/Hello/Mongo.Hello.Response.swift
@@ -102,7 +102,7 @@ extension Mongo.Hello.Response:BSONDictionaryDecodable
         {
             let tags:BSON.Fields = try bson["tags"]?.decode(to: BSON.Fields.self) ?? .init()
             let peerlist:Mongo.Peerlist = .init(
-                primary: try bson["primary"].decode(to: Mongo.Host.self),
+                primary: try bson["primary"]?.decode(to: Mongo.Host.self),
                 arbiters: try bson["arbiters"]?.decode(to: [Mongo.Host].self) ?? [],
                 passives: try bson["passives"]?.decode(to: [Mongo.Host].self) ?? [],
                 hosts: try bson["hosts"].decode(to: [Mongo.Host].self),

--- a/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.CitizenRights.swift
+++ b/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.CitizenRights.swift
@@ -1,0 +1,33 @@
+extension Mongo.ReplicaSetConfiguration
+{
+    @frozen public
+    struct CitizenRights:Sendable
+    {
+        public
+        let priority:Double
+        public
+        let votes:Int
+
+        @inlinable public
+        init()
+        {
+            self.priority = 1
+            self.votes = 1
+        }
+
+        @inlinable public
+        init?(priority:Double, votes:Int)
+        {
+            if  priority > 0,
+                votes > 0
+            {   
+                self.priority = priority
+                self.votes = votes
+            }
+            else
+            {
+                return nil
+            }
+        }
+    }
+}

--- a/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.Member.swift
+++ b/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.Member.swift
@@ -1,0 +1,91 @@
+import BSONSchema
+
+extension Mongo.ReplicaSetConfiguration
+{
+    public
+    struct Member:Sendable
+    {
+        public
+        let id:Int64
+        public
+        let rights:MemberRights
+        public
+        let tags:BSON.Fields
+        public
+        let host:Mongo.Host
+
+        public
+        init(id:Int64,
+            rights:MemberRights = .citizen(.init()),
+            tags:BSON.Fields = .init(),
+            host:Mongo.Host)
+        {
+            self.id = id
+            self.rights = rights
+            self.tags = tags
+            self.host = host
+        }
+    }
+}
+extension Mongo.ReplicaSetConfiguration.Member:BSONDictionaryDecodable
+{
+    @inlinable public
+    init(bson:BSON.Dictionary<some RandomAccessCollection<UInt8>>) throws
+    {
+        let rights:Mongo.ReplicaSetConfiguration.MemberRights
+
+        if case true? = try bson["arbiterOnly"]?.decode(to: Bool.self)
+        {
+            rights = .arbiter
+        }
+        else
+        {
+            let priority:Double = try bson["priority"]?.decode(to: Double.self) ?? 1
+            let votes:Int = try bson["votes"]?.decode(to: Int.self) ?? 1
+
+            if  let citizen:Mongo.ReplicaSetConfiguration.CitizenRights = .init(
+                    priority: priority,
+                    votes: votes)
+            {
+                rights = .citizen(citizen)
+            }
+            else
+            {
+                rights = .resident(.init(
+                    buildsIndexes: try bson["buildIndexes"]?.decode(to: Bool.self) ?? true,
+                    isHidden: try bson["hidden"]?.decode(to: Bool.self) ?? false,
+                    votes: votes))
+            }
+        }
+        self.init(id: try bson["_id"].decode(to: Int64.self),
+            rights: rights,
+            tags: try bson["tags"]?.decode(to: BSON.Fields.self) ?? .init(),
+            host: try bson["host"].decode(to: Mongo.Host.self))
+    }
+}
+extension Mongo.ReplicaSetConfiguration.Member:BSONDocumentEncodable
+{
+    public
+    func encode(to bson:inout BSON.Fields)
+    {
+        bson["_id"] = self.id
+
+        switch self.rights
+        {
+        case .resident(let resident):
+            bson["buildIndexes"] = resident.buildsIndexes
+            bson["hidden"] = resident.isHidden
+            bson["votes"] = resident.votes
+        
+        case .arbiter:
+            bson["arbiterOnly"] = true
+        
+        case .citizen(let citizen):
+            bson["priority"] = citizen.priority
+            bson["votes"] = citizen.votes
+        }
+
+        bson["tags", elide: true] = self.tags
+        bson["host"] = self.host
+    }
+}

--- a/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.MemberRights.swift
+++ b/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.MemberRights.swift
@@ -1,0 +1,17 @@
+extension Mongo.ReplicaSetConfiguration
+{
+    @frozen public
+    enum MemberRights:Sendable
+    {
+        /// A configuration for a resident member. Residents can vote for primary,
+        /// but cannot become primary. Residents can be hidden and delayed.
+        case resident(ResidentRights)
+        /// A configuration for an arbiter. Arbiters only exist to vote for primary,
+        /// in order to break ties, and have no other settings.
+        case arbiter
+        /// A configuration for a citizen member. Citizens always cast at least
+        /// one vote for primary, and can themselves become primary, based on their
+        /// priority.
+        case citizen(CitizenRights)
+    }
+}

--- a/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.ResidentRights.swift
+++ b/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.ResidentRights.swift
@@ -1,0 +1,22 @@
+extension Mongo.ReplicaSetConfiguration
+{
+    @frozen public
+    struct ResidentRights:Sendable
+    {
+        public
+        let buildsIndexes:Bool
+        public
+        let isHidden:Bool
+        public
+        let votes:Int
+        // TODO: model delay
+
+        @inlinable public
+        init(buildsIndexes:Bool = true, isHidden:Bool = false, votes:Int)
+        {
+            self.buildsIndexes = buildsIndexes
+            self.isHidden = isHidden
+            self.votes = votes
+        }
+    }
+}

--- a/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.swift
+++ b/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.swift
@@ -1,0 +1,58 @@
+import BSONSchema
+
+extension Mongo
+{
+    public
+    struct ReplicaSetConfiguration:Sendable
+    {
+        public
+        let name:String
+        public
+        let writeConcernMajorityJournalDefault:Bool
+        public
+        let members:[Member]
+        public
+        let version:Int
+        public
+        let term:Int
+
+        public
+        init(name:String,
+            writeConcernMajorityJournalDefault:Bool = true,
+            members:[Member],
+            version:Int,
+            term:Int)
+        {
+            self.name = name
+            self.writeConcernMajorityJournalDefault = writeConcernMajorityJournalDefault
+            self.members = members
+            self.version = version
+            self.term = term
+        }
+    }
+}
+extension Mongo.ReplicaSetConfiguration:BSONDictionaryDecodable
+{
+    @inlinable public
+    init(bson:BSON.Dictionary<some RandomAccessCollection<UInt8>>) throws
+    {
+        self.init(name: try bson["_id"].decode(to: String.self),
+            writeConcernMajorityJournalDefault:
+                try bson["writeConcernMajorityJournalDefault"]?.decode(to: Bool.self) ?? true,
+            members: try bson["members"].decode(to: [Member].self),
+            version: try bson["version"].decode(to: Int.self),
+            term: try bson["term"].decode(to: Int.self))
+    }
+}
+extension Mongo.ReplicaSetConfiguration:BSONDocumentEncodable
+{
+    public
+    func encode(to bson:inout BSON.Fields)
+    {
+        bson["_id"] = self.name
+        bson["writeConcernMajorityJournalDefault"] = self.writeConcernMajorityJournalDefault
+        bson["members"] = self.members
+        bson["version"] = self.version
+        bson["term"] = self.term
+    }
+}

--- a/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetGetConfiguration.swift
+++ b/Sources/MongoSessions/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetGetConfiguration.swift
@@ -1,0 +1,53 @@
+import BSONSchema
+import NIOCore
+
+extension Mongo
+{
+    public
+    struct ReplicaSetGetConfiguration:Sendable
+    {
+        public
+        init()
+        {
+        }
+    }
+}
+extension Mongo.ReplicaSetGetConfiguration:MongoCommand
+{
+    public
+    typealias Response = Mongo.ReplicaSetConfiguration
+
+    // we need to provide this witness, to prevent the default implementation
+    // from running (which will fail to unnest one level of 'config')
+    public static
+    func decode(reply bson:BSON.Dictionary<ByteBufferView>)
+        throws -> Mongo.ReplicaSetConfiguration
+    {
+        try self._decode(reply: bson)
+    }
+    @inlinable public static
+    func decode(reply bson:BSON.Dictionary<some RandomAccessCollection<UInt8>>)
+        throws -> Mongo.ReplicaSetConfiguration
+    {
+        try self._decode(reply: bson)
+    }
+    @inlinable public static
+    func _decode(reply bson:BSON.Dictionary<some RandomAccessCollection<UInt8>>)
+        throws -> Mongo.ReplicaSetConfiguration
+    {
+        print([String].init(bson.items.keys))
+        return try bson["config"].decode(to: Mongo.ReplicaSetConfiguration.self)
+    }
+    
+    public
+    func encode(to bson:inout BSON.Fields)
+    {
+        bson["replSetGetConfig"] = 1 as Int32
+    }
+}
+extension Mongo.ReplicaSetGetConfiguration:MongoReadOnlyCommand
+{
+}
+extension Mongo.ReplicaSetGetConfiguration:MongoImplicitSessionCommand
+{
+}

--- a/Sources/MongoSessions/Topologies/Mongo.TopologyMonitor.swift
+++ b/Sources/MongoSessions/Topologies/Mongo.TopologyMonitor.swift
@@ -98,7 +98,6 @@ extension Mongo.TopologyMonitor
     func update(host:Mongo.Host, connection:Mongo.Connection,
         metadata:Mongo.ServerMetadata) -> Bool
     {
-        print(metadata.type)
         let admitted:Bool = self.topology.update(host: host, connection: connection,
             metadata: metadata.type)
         { 

--- a/Sources/MongoSessions/Topologies/Mongo.TopologyMonitor.swift
+++ b/Sources/MongoSessions/Topologies/Mongo.TopologyMonitor.swift
@@ -98,6 +98,7 @@ extension Mongo.TopologyMonitor
     func update(host:Mongo.Host, connection:Mongo.Connection,
         metadata:Mongo.ServerMetadata) -> Bool
     {
+        print(metadata.type)
         let admitted:Bool = self.topology.update(host: host, connection: connection,
             metadata: metadata.type)
         { 
@@ -248,8 +249,13 @@ extension Mongo.TopologyMonitor
             let started:ContinuousClock.Instant = self.driver.clock.now
             let id:UInt = self.awaiting.open()
 
+            #if compiler(>=5.8)
             async
             let _:Void = self.fail(request: id, once: started.advanced(by: timeout))
+            #else
+            async
+            let __:Void = self.fail(request: id, once: started.advanced(by: timeout))
+            #endif
 
             return try await withCheckedThrowingContinuation
             {

--- a/Tests/MongoDB/Main.swift
+++ b/Tests/MongoDB/Main.swift
@@ -14,7 +14,7 @@ enum Main:AsyncTests
         let driver:Mongo.Driver = .init(
             credentials: .init(authentication: .sasl(.sha256),
                 username: "root",
-                password: "password"),
+                password: "80085"),
             executor: executor,
             timeout: .seconds(10))
         

--- a/Tests/MongoSessions/Main.swift
+++ b/Tests/MongoSessions/Main.swift
@@ -60,7 +60,7 @@ extension Main
                 {
                     try await $1.seeded(with: [seed])
                     {
-                        try await $0.withMutableSession(timeout: .seconds(1))
+                        try await $0.withMutableSession(timeout: .seconds(5))
                         {
                             _ in
                         }

--- a/Tests/MongoSessions/Main.swift
+++ b/Tests/MongoSessions/Main.swift
@@ -161,7 +161,7 @@ extension Main
             await $0.test(with: DriverEnvironment.init(name: "defaulted",
                 credentials: .init(authentication: nil,
                     username: "root",
-                    password: "password"),
+                    password: "80085"),
                 executor: executor))
             {
                 try await $1.seeded(with: [single])
@@ -176,7 +176,7 @@ extension Main
             await $0.test(with: DriverEnvironment.init(name: "scram-sha256",
                 credentials: .init(authentication: .sasl(.sha256),
                     username: "root",
-                    password: "password"),
+                    password: "80085"),
                 executor: executor))
             {
                 try await $1.seeded(with: [single])
@@ -192,7 +192,7 @@ extension Main
         await tests.test(with: DriverEnvironment.init(name: "authentication-unsupported",
             credentials: .init(authentication: .x509,
                 username: "root",
-                password: "password"),
+                password: "80085"),
             executor: executor))
         {
             (tests:inout Tests, driver:Mongo.Driver) in

--- a/Tests/MongoSessions/Main.swift
+++ b/Tests/MongoSessions/Main.swift
@@ -2,9 +2,18 @@ import NIOPosix
 import MongoSessions
 import Testing
 
-@main 
-enum Main:AsyncTests
+@main
+enum Main
 {
+    public static
+    func main() async
+    {
+        var tests:Tests = .init()
+        await Self.run(tests: &tests)
+        print(tests.results.passed)
+        print(tests.results.failed)
+    }
+
     static
     func run(tests:inout Tests) async
     {


### PR DESCRIPTION
-  sets up a mock standalone deployment in docker
-  sets up a mock replica set deployment in docker
-  adds support for `replSetGetConfig` in the driver
-  adds tests for `replSetGetConfig`
-  adds all existing unit tests, except BSON tests to CI pipeline

TODO: add BSON tests to CI