### PR TITLE
gossip the $clusterTime

### DIFF
--- a/Sources/MongoDriver/Connections/Mongo.Reply.swift
+++ b/Sources/MongoDriver/Connections/Mongo.Reply.swift
@@ -12,13 +12,13 @@ extension Mongo
         let result:Result<BSON.Dictionary<ByteBufferView>, MongoChannel.ServerError>
 
         @usableFromInline
-        let operationTime:Mongo.Instant?
+        let operationTime:Instant?
         @usableFromInline
-        let clusterTime:Mongo.Instant?
+        let clusterTime:ClusterTime?
 
         init(result:Result<BSON.Dictionary<ByteBufferView>, MongoChannel.ServerError>,
-            operationTime:Mongo.Instant?,
-            clusterTime:Mongo.Instant?)
+            operationTime:Instant?,
+            clusterTime:ClusterTime?)
         {
             self.result = result
             self.operationTime = operationTime
@@ -38,11 +38,8 @@ extension Mongo.Reply
 
         let operationTime:Mongo.Instant? = try dictionary["operationTime"]?.decode(
             to: Mongo.Instant.self)
-        let clusterTime:Mongo.Instant? = try dictionary["$clusterTime"]?.decode(
-            as: BSON.Dictionary<ByteBufferView>.self)
-        {
-            try $0["clusterTime"].decode(to: Mongo.Instant.self)
-        }
+        let clusterTime:Mongo.ClusterTime? = try dictionary["$clusterTime"]?.decode(
+            to: Mongo.ClusterTime.self)
         
         if  status.ok
         {

--- a/Sources/MongoDriver/Connections/MongoChannel.swift
+++ b/Sources/MongoDriver/Connections/MongoChannel.swift
@@ -208,7 +208,7 @@ extension MongoChannel
     /// Encodes the given labeled command to a document, sends it over this connection and
     /// awaits its response.
     @inlinable public
-    func run(labeled:__owned Mongo.SessionLabeled<some MongoCommand>,
+    func run(labeled:__owned Mongo.Labeled<some MongoCommand>,
         against database:Mongo.Database) async throws -> Mongo.Reply
     {
         try .init(message: try await self.send(

--- a/Sources/MongoDriver/Monitoring/Mongo.ClusterTime.swift
+++ b/Sources/MongoDriver/Monitoring/Mongo.ClusterTime.swift
@@ -1,0 +1,37 @@
+import BSONSchema
+
+extension Mongo
+{
+    public final
+    class ClusterTime:Sendable
+    {
+        let signature:BSON.Fields
+        public
+        let max:Mongo.Instant
+
+        @usableFromInline
+        init(signature:BSON.Fields, max:Mongo.Instant)
+        {
+            self.signature = signature
+            self.max = max
+        }
+    }
+}
+extension Mongo.ClusterTime:BSONDocumentEncodable
+{
+    public
+    func encode(to bson:inout BSON.Fields)
+    {
+        bson["signature", elide: false] = self.signature
+        bson["clusterTime"] = self.max
+    }
+}
+extension Mongo.ClusterTime:BSONDictionaryDecodable
+{
+    @inlinable public convenience
+    init(bson:BSON.Dictionary<some RandomAccessCollection<UInt8>>) throws
+    {
+        self.init(signature: try bson["signature"].decode(to: BSON.Fields.self),
+            max: try bson["clusterTime"].decode(to: Mongo.Instant.self))
+    }
+}

--- a/Sources/MongoDriver/Sessions/Mongo.SessionPool.swift
+++ b/Sources/MongoDriver/Sessions/Mongo.SessionPool.swift
@@ -50,7 +50,7 @@ extension Mongo.SessionPool
     nonisolated
     func with<Session, Success>(_:Session.Type, timeout:Duration,
         _ body:(Session) async throws -> Success) async throws -> Success
-        where Session:MongoConcurrencyDomain
+        where Session:_MongoConcurrencyDomain
     {
         //  yes, we do need to `await` on the medium before checking out a session,
         //  to avoid generating excessive sessions if a medium is temporarily unavailable

--- a/Sources/MongoDriver/Sessions/_MongoConcurrencyDomain.swift
+++ b/Sources/MongoDriver/Sessions/_MongoConcurrencyDomain.swift
@@ -1,4 +1,5 @@
-protocol MongoConcurrencyDomain:Identifiable<Mongo.SessionIdentifier>
+/// TODO: do we really need this?
+protocol _MongoConcurrencyDomain:Identifiable<Mongo.SessionIdentifier>
 {
     static
     var medium:Mongo.SessionMediumSelector { get }
@@ -11,12 +12,4 @@ protocol MongoConcurrencyDomain:Identifiable<Mongo.SessionIdentifier>
     var monitor:Mongo.Monitor { get }
     var metadata:Mongo.SessionMetadata { get }
     var id:Mongo.SessionIdentifier { get }
-}
-extension MongoConcurrencyDomain
-{
-    var _time:UInt64?
-    {
-        let time:UInt64 = self.monitor.time.load(ordering: .relaxed)
-        return time == 0 ? nil : time
-    }
 }

--- a/Sources/MongoDriver/Transactions/Mongo.Instant.swift
+++ b/Sources/MongoDriver/Transactions/Mongo.Instant.swift
@@ -65,3 +65,11 @@ extension Mongo.Instant:BSONEncodable
         field.encode(uint64: self.timestamp)
     }
 }
+extension Mongo.Instant:CustomStringConvertible
+{
+    public
+    var description:String
+    {
+        "\(self.timestamp >> 32)+\(self.timestamp & 0x0000_0000_ffff_ffff)"
+    }
+}

--- a/Tests/MongoDriver/Main.swift
+++ b/Tests/MongoDriver/Main.swift
@@ -32,7 +32,7 @@ extension Main
     {
         print("running tests for replicated topology (hosts: \(replicas))")
         //  we should be able to connect to the primary using any seed
-        await tests.group("replication")
+        await tests.group("replica-set-seeding")
         {
             for seed:MongoTopology.Host in replicas
             {
@@ -50,6 +50,49 @@ extension Main
                                 command: Mongo.ReplicaSetGetConfiguration.init())
                         }
                     }
+                }
+            }
+        }
+        await tests.test(with: DriverEnvironment.init(
+            name: "replica-set-cluster-times",
+            credentials: nil,
+            executor: executor))
+        {
+            (tests:inout Tests, driver:Mongo.DriverBootstrap) in
+
+            try await driver.withSessionPool(seedlist: .init(replicas))
+            {
+                try await $0.withMutableSession(timeout: .seconds(5))
+                {
+                    // should be `nil` here, but eventually we want to get
+                    // `$clusterTime` from Hellos too
+                    // print($0.monitor.clusterTime)
+
+                    let _:Mongo.ReplicaSetConfiguration = try await $0.run(
+                        command: Mongo.ReplicaSetGetConfiguration.init())
+                    
+                    let original:Mongo.ClusterTime? = tests.unwrap($0.monitor.clusterTime,
+                        name: "first")
+
+                    //  mongod only updates its timestamps on write, or every 10s.
+                    //  we don’t have any commands in this module that write, so we
+                    //  just have to wait 10s...
+
+                    //  TODO: figure out a way to perturb the cluster time without
+                    //  waiting 10s
+                    try await Task.sleep(for: .milliseconds(10000))
+
+                    let _:Mongo.ReplicaSetConfiguration = try await $0.run(
+                        command: Mongo.ReplicaSetGetConfiguration.init())
+                    
+                    if  let updated:Mongo.ClusterTime = tests.unwrap($0.monitor.clusterTime,
+                            name: "second"),
+                        let original:Mongo.ClusterTime
+                    {
+                        tests.assert(original.max != updated.max,
+                            name: "updated")
+                    }
+                        
                 }
             }
         }


### PR DESCRIPTION
implements cluster time gossip (as described in https://github.com/mongodb/specifications/blob/a9096ad069e8af0f5973c9d0ca75da57e4c63616/source/sessions/driver-sessions.rst#how-to-compute-the-clustertime-to-send-to-a-server) for replica-set topologies, and adds a test