### PR TITLE
Expand tests

### DIFF
--- a/.github/mongonet/create-replica-set.js
+++ b/.github/mongonet/create-replica-set.js
@@ -1,31 +1,50 @@
-db = connect('mongodb://mongo-1:27017/admin');
+db = connect('mongodb://mongo-0:27017/admin');
 db.runCommand({'replSetInitiate': {
     "_id": "test-set",
     "version": 1,
     "members": [
         {
+            "_id": 0,
+            "host": "mongo-0:27017",
+            "tags": {
+                "priority": "high",
+                "name": "A",
+            },
+            "priority": 2
+        },
+        {
             "_id": 1,
             "host": "mongo-1:27017",
             "tags": {
-                "c": "C",
-                "a": "A",
-                "b": "B",
+                "priority": "low",
+                "name": "B",
             },
-            "priority": 2
+            "priority": 1
         },
         {
             "_id": 2,
             "host": "mongo-2:27017",
             "tags": {
-                "b": "B",
-                "d": "D",
-                "c": "C"
+                "priority": "zero",
+                "name": "C",
             },
-            "priority": 1
+            "priority": 0
         },
         {
             "_id": 3,
             "host": "mongo-3:27017",
+            "tags": {
+                "priority": "zero",
+                "name": "H",
+            },
+            "secondaryDelaySecs": 5,
+            "priority": 0,
+            "votes": 0,
+            "hidden": true
+        },
+        {
+            "_id": 4,
+            "host": "mongo-4:27017",
             "priority": 0,
             "arbiterOnly": true
         }

--- a/.github/mongonet/docker-compose.yml
+++ b/.github/mongonet/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         networks:
             - mongonet
         ports:
-            - 30000:27017
+            - 40000:27017
         restart: always
         volumes:
             - ./create-users.js:/docker-entrypoint-initdb.d/create-users.js
@@ -15,8 +15,20 @@ services:
             - ./data/db:/data/db
         command: mongod --config /etc/mongod.conf
 
-    # a mock replica set deployment. *every* member runs the init script,
-    # the last one to do so will know about all the other members.
+    mongo-0:
+        image: mongo:latest
+        hostname: mongo-0
+        networks:
+            - mongonet
+        ports:
+            - 30000:27017
+        restart: always
+        volumes:
+            # cannot put this in docker-entrypoint-initdb.d, it does not work
+            - ./create-replica-set.js:/create-replica-set.js
+            - ./test-set.conf:/etc/mongod.conf
+            - ./data-0/db:/data/db
+        command: mongod --config /etc/mongod.conf
     mongo-1:
         image: mongo:latest
         hostname: mongo-1
@@ -54,6 +66,18 @@ services:
         volumes:
             - ./test-set.conf:/etc/mongod.conf
             - ./data-3/db:/data/db
+        command: mongod --config /etc/mongod.conf
+    mongo-4:
+        image: mongo:latest
+        hostname: mongo-4
+        networks:
+            - mongonet
+        ports:
+            - 30004:27017
+        restart: always
+        volumes:
+            - ./test-set.conf:/etc/mongod.conf
+            - ./data-4/db:/data/db
         command: mongod --config /etc/mongod.conf
 
 networks: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
             -   name: initialize replica set
                 run: |
                     timeout 30s bash -c \
-                    'until docker exec -t mongonet-mongo-1-1 /bin/mongosh --file /create-replica-set.js; do sleep 1; done'
+                    'until docker exec -t mongonet-mongo-0-1 /bin/mongosh --file /create-replica-set.js; do sleep 1; done'
             
             -   name: build and test
                 run: |

--- a/Sources/MongoDB/Commands/Fsync/Mongo.Fsync.swift
+++ b/Sources/MongoDB/Commands/Fsync/Mongo.Fsync.swift
@@ -1,0 +1,32 @@
+import BSONEncoding
+
+extension Mongo
+{
+    public
+    struct Fsync:Sendable
+    {
+        public
+        let lock:Bool
+
+        public
+        init(lock:Bool)
+        {
+            self.lock = lock
+        }
+    }
+}
+extension Mongo.Fsync:MongoCommand
+{
+    public
+    typealias Response = Mongo.FsyncLock
+
+    public
+    func encode(to bson:inout BSON.Fields)
+    {
+        bson["fsync"] = 1 as Int32
+        bson["lock"] = self.lock
+    }
+}
+extension Mongo.Fsync:MongoImplicitSessionCommand
+{
+}

--- a/Sources/MongoDB/Commands/Fsync/Mongo.FsyncLock.swift
+++ b/Sources/MongoDB/Commands/Fsync/Mongo.FsyncLock.swift
@@ -1,0 +1,27 @@
+import BSONDecoding
+
+extension Mongo
+{
+    /// Information about a MongoDB ``Fsync`` lock.
+    @frozen public
+    struct FsyncLock:Hashable, Equatable, Sendable
+    {
+        /// The current retain count of the relevant lock.
+        public
+        let count:Int
+
+        @inlinable public
+        init(count:Int)
+        {
+            self.count = count
+        }
+    }
+}
+extension Mongo.FsyncLock:BSONDictionaryDecodable
+{
+    @inlinable public
+    init(bson:BSON.Dictionary<some RandomAccessCollection<UInt8>>) throws
+    {
+        self.init(count: try bson["lockCount"].decode(to: Int.self))
+    }
+}

--- a/Sources/MongoDB/Commands/FsyncUnlock/Mongo.FsyncUnlock.swift
+++ b/Sources/MongoDB/Commands/FsyncUnlock/Mongo.FsyncUnlock.swift
@@ -1,0 +1,27 @@
+import BSONEncoding
+
+extension Mongo
+{
+    public
+    struct FsyncUnlock:Sendable
+    {
+        public
+        init()
+        {
+        }
+    }
+}
+extension Mongo.FsyncUnlock:MongoCommand
+{
+    public
+    typealias Response = Mongo.FsyncLock
+
+    public
+    func encode(to bson:inout BSON.Fields)
+    {
+        bson["fsyncUnlock"] = 1 as Int32
+    }
+}
+extension Mongo.FsyncUnlock:MongoImplicitSessionCommand
+{
+}

--- a/Sources/MongoDriver/Clusters/Mongo.ReadPreferenceError.swift
+++ b/Sources/MongoDriver/Clusters/Mongo.ReadPreferenceError.swift
@@ -1,11 +1,12 @@
 extension Mongo
 {
     public
-    struct ReadPreferenceError:Error
+    struct ReadPreferenceError:Equatable, Error
     {
         public
         let preference:ReadPreference
 
+        public
         init(preference:ReadPreference)
         {
             self.preference = preference

--- a/Sources/MongoDriver/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.Rights.swift
+++ b/Sources/MongoDriver/Commands/ReplicaSetGetConfiguration/Mongo.ReplicaSetConfiguration.Rights.swift
@@ -10,14 +10,14 @@ extension Mongo.ReplicaSetConfiguration
 extension Mongo.ReplicaSetConfiguration.Rights
 {
     /// Configures a citizen with a priority of [`1.0`]().
-    @inlinable public
+    @inlinable public static
     var citizen:Self
     {
         .citizen(.init())
     }
     /// Configures a resident with default settings.
     /// (Builds indexes, and is not delayed.)
-    @inlinable public
+    @inlinable public static
     var resident:Self
     {
         .resident(.init())

--- a/Tests/MongoDB/Main.swift
+++ b/Tests/MongoDB/Main.swift
@@ -9,7 +9,9 @@ enum Main:AsyncTests
     static
     func run(tests:inout Tests) async
     {
-        let single:MongoTopology.Host = .init(name: "mongo-single", port: 27017)
+        let executor:MultiThreadedEventLoopGroup = .init(numberOfThreads: 2)
+
+        let standalone:MongoTopology.Host = .init(name: "mongo-single", port: 27017)
         let members:Set<MongoTopology.Host> =
         [
             .init(name: "mongo-1", port: 27017),
@@ -17,339 +19,36 @@ enum Main:AsyncTests
             .init(name: "mongo-3", port: 27017),
         ]
 
-        let executor:MultiThreadedEventLoopGroup = .init(numberOfThreads: 2)
+        await tests.group("replicated-topology")
+        {
+            print("running tests for replicated topology (hosts: \(members))")
 
-        print("running tests for single topology (host: \(single))")
-        await self.run(tests: &tests, bootstrap: .init(
+            let bootstrap:Mongo.DriverBootstrap = .init(
+                commandTimeout: .seconds(10),
+                credentials: nil,
+                executor: executor)
+
+            await TestDatabases(&$0, bootstrap: bootstrap, hosts: members)
+            await TestInsert(&$0, bootstrap: bootstrap, hosts: members)
+            await TestFind(&$0, bootstrap: bootstrap, hosts: members)
+            await TestCursors(&$0, bootstrap: bootstrap, hosts: members)
+        }
+
+        await tests.group("single-topology")
+        {
+            print("running tests for single topology (host: \(standalone))")
+
+            let bootstrap:Mongo.DriverBootstrap = .init(
                 commandTimeout: .seconds(10),
                 credentials: .init(authentication: .sasl(.sha256),
                     username: "root",
                     password: "80085"),
-                executor: executor),
-            hosts: [single],
-            on: executor)
-        
-        print("running tests for replicated topology (hosts: \(members))")
-        await self.run(tests: &tests, bootstrap: .init(
-                commandTimeout: .seconds(10),
-                credentials: nil,
-                executor: executor),
-            hosts: members,
-            on: executor)
-    }
-    static
-    func run(tests:inout Tests,
-        bootstrap:Mongo.DriverBootstrap,
-        hosts:Set<MongoTopology.Host>,
-        on executor:MultiThreadedEventLoopGroup) async
-    {
-        await tests.test(with: DatabaseEnvironment.init(bootstrap: bootstrap,
-            database: "databases",
-            hosts: hosts))
-        {
-            (tests:inout Tests, context:DatabaseEnvironment.Context) in
+                executor: executor)
 
-            await tests.test(name: "create-database-by-collection")
-            {
-                _ in try await context.pool.run(
-                    command: Mongo.Create.init(collection: "placeholder"), 
-                    against: context.database)
-            }
-
-            await tests.test(name: "list-database-names")
-            {
-                let names:[Mongo.Database] = try await context.pool.run(
-                    command: Mongo.ListDatabases.NameOnly.init())
-                $0.assert(names.contains(context.database),
-                    name: "contains")
-            }
-
-            await tests.test(name: "list-databases")
-            {
-                let (size, databases):(Int, [Mongo.DatabaseMetadata]) = try await context.pool.run(
-                    command: Mongo.ListDatabases.init())
-                $0.assert(size > 0,
-                    name: "nonzero-size")
-                $0.assert(databases.contains { $0.database == context.database },
-                    name: "contains")
-            }
-        }
-        
-        await tests.test(with: DatabaseEnvironment.init(bootstrap: bootstrap,
-            database: "collection-insert",
-            hosts: hosts))
-        {
-            (tests:inout Tests, context:DatabaseEnvironment.Context) in
-
-            let collection:Mongo.Collection = "ordinals"
-
-            await tests.test(name: "insert-one")
-            {
-                let expected:Mongo.InsertResponse = .init(inserted: 1)
-                let response:Mongo.InsertResponse = try await context.pool.run(
-                    command: Mongo.Insert<Ordinals>.init(collection: collection,
-                        elements: .init(identifiers: 0 ..< 1)),
-                    against: context.database)
-                
-                $0.assert(response ==? expected, name: "response")
-            }
-
-            await tests.test(name: "insert-multiple")
-            {
-                let expected:Mongo.InsertResponse = .init(inserted: 15)
-                let response:Mongo.InsertResponse = try await context.pool.run(
-                    command: Mongo.Insert<Ordinals>.init(collection: collection,
-                        elements: .init(identifiers: 1 ..< 16)),
-                    against: context.database)
-                
-                $0.assert(response ==? expected, name: "response")
-            }
-
-            await tests.test(name: "insert-duplicate-id")
-            {
-                let expected:Mongo.InsertResponse = .init(inserted: 0,
-                    writeErrors:
-                    [
-                        .init(index: 0,
-                            message:
-                            """
-                            E11000 duplicate key error collection: \
-                            \(context.database).\(collection) index: _id_ dup key: { _id: 0 }
-                            """,
-                            code: 11000),
-                    ])
-                let response:Mongo.InsertResponse = try await context.pool.run(
-                    command: Mongo.Insert<Ordinals>.init(collection: collection,
-                        elements: .init(identifiers: 0 ..< 1)),
-                    against: context.database)
-                
-                $0.assert(response ==? expected, name: "response")
-            }
-
-            await tests.test(name: "insert-ordered")
-            {
-                let expected:Mongo.InsertResponse = .init(inserted: 8,
-                    writeErrors:
-                    [
-                        .init(index: 8,
-                            message:
-                            """
-                            E11000 duplicate key error collection: \
-                            \(context.database).\(collection) index: _id_ dup key: { _id: 0 }
-                            """,
-                            code: 11000),
-                    ])
-                let response:Mongo.InsertResponse = try await context.pool.run(
-                    command: Mongo.Insert<Ordinals>.init(collection: collection,
-                        elements: .init(identifiers: -8 ..< 32)),
-                    against: context.database)
-                
-                $0.assert(response ==? expected, name: "response")
-            }
-
-            await tests.test(name: "insert-unordered")
-            {
-                let expected:Mongo.InsertResponse = .init(inserted: 24,
-                    writeErrors: (8 ..< 32).map
-                    {
-                        .init(index: $0,
-                            message:
-                            """
-                            E11000 duplicate key error collection: \
-                            \(context.database).\(collection) index: _id_ dup key: { _id: \($0 - 16) }
-                            """,
-                            code: 11000)
-                    })
-                let response:Mongo.InsertResponse = try await context.pool.run(
-                    command: Mongo.Insert<Ordinals>.init(collection: collection,
-                        elements: .init(identifiers: -16 ..< 32),
-                        ordered: false),
-                    against: context.database)
-                
-                $0.assert(response ==? expected, name: "response")
-            }
-        }
-        
-        await tests.test(with: DatabaseEnvironment.init(bootstrap: bootstrap,
-            database: "collection-find",
-            hosts: hosts))
-        {
-            (tests:inout Tests, context:DatabaseEnvironment.Context) in
-
-            let collection:Mongo.Collection = "ordinals"
-            let ordinals:Ordinals = .init(identifiers: 0 ..< 100)
-
-            await tests.test(name: "initialize")
-            {
-                let expected:Mongo.InsertResponse = .init(inserted: 100)
-                let response:Mongo.InsertResponse = try await context.pool.run(
-                    command: Mongo.Insert<Ordinals>.init(collection: collection,
-                        elements: ordinals),
-                    against: context.database)
-                
-                $0.assert(response ==? expected, name: "response")
-            }
-            // await tests.test(name: "single-batch")
-            // {
-            //     let expected:Mongo.Cursor<Ordinal> = .init(id: 0,
-            //         namespace: .init(database, collection),
-            //         elements: [Ordinal].init(ordinals.prefix(10)))
-            //     let cursor:Mongo.Cursor<Ordinal> = try await cluster.run(
-            //         command: Mongo.Find<Ordinal>.init(collection: collection,
-            //             returning: .batch(of: 10)),
-            //         against: database)
-
-            //     $0.assert(cursor ==? expected, name: "cursor")
-            // }
-            await tests.test(name: "multiple-batches")
-            {
-                (tests:inout Tests) in
-
-                try await context.pool.withSession
-                {
-                    try await $0.run(query: Mongo.Find<Ordinal>.init(
-                            collection: collection,
-                            stride: 10),
-                        against: context.database)
-                    {
-                        var expected:Ordinals.Iterator = ordinals.makeIterator()
-                        for try await batch:[Ordinal] in $0
-                        {
-                            for returned:Ordinal in batch
-                            {
-                                if  let expected:Ordinal = tests.unwrap(expected.next(),
-                                        name: "next-expected")
-                                {
-                                    tests.assert(returned == expected,
-                                        name: expected.id.description)
-                                }
-                            }
-                        }
-                        tests.assert(expected.next() == nil, name: "next-returned")
-                    }
-                }
-            }
-            await tests.test(with: SessionEnvironment.init(name: "filtering",
-                pool: context.pool))
-            {
-                (tests:inout Tests, session:Mongo.Session) in
-            
-                try await session.run(query: Mongo.Find<Ordinal>.init(
-                        collection: collection,
-                        stride: 10,
-                        filter: .init
-                        {
-                            $0["ordinal"] = ["$mod": [3, 0]]
-                        }),
-                    against: context.database)
-                {
-                    var expected:Array<Ordinal>.Iterator = 
-                        ordinals.filter { $0.value % 3 == 0 }.makeIterator()
-                    for try await batch:[Ordinal] in $0
-                    {
-                        for returned:Ordinal in batch
-                        {
-                            if  let expected:Ordinal = tests.unwrap(expected.next(),
-                                    name: "next-expected")
-                            {
-                                tests.assert(returned == expected, name: expected.id.description)
-                            }
-                        }
-                    }
-                    tests.assert(expected.next() == nil, name: "next-returned")
-                }
-            }
-            await tests.test(with: SessionEnvironment.init(name: "cursor-cleanup-normal",
-                pool: context.pool))
-            {
-                (tests:inout Tests, session:Mongo.Session) in
-
-                try await session.run(query: Mongo.Find<Ordinal>.init(
-                        collection: collection,
-                        stride: 10),
-                    against: context.database)
-                {
-                    guard   let cursor:Mongo.CursorIdentifier =
-                                tests.unwrap($0.current.next, name: "cursor-id")
-                    else
-                    {
-                        return
-                    }
-                    for try await _:[Ordinal] in $0
-                    {
-                    }
-                    let cursors:Mongo.KillCursors.Response = try await session.run(
-                        command: Mongo.KillCursors.init([cursor], 
-                            collection: $0.collection),
-                        against: $0.database)
-                    // if the cursor is already dead, killing it manually will return 'notFound'.
-                    tests.assert(cursors.alive **? [], name: "cursors-alive")
-                    tests.assert(cursors.killed **? [], name: "cursors-killed")
-                    tests.assert(cursors.unknown **? [], name: "cursors-unknown")
-                    tests.assert(cursors.notFound **? [cursor], name: "cursors-not-found")
-                }
-            }
-            await tests.test(with: SessionEnvironment.init(name: "cursor-cleanup-interruption",
-                pool: context.pool))
-            {
-                (tests:inout Tests, session:Mongo.Session) in
-
-                let cursor:Mongo.CursorIdentifier? =
-                    try await session.run(
-                        query: Mongo.Find<Ordinal>.init(collection: collection, stride: 10),
-                        against: context.database)
-                {
-                    if  let cursor:Mongo.CursorIdentifier = tests.unwrap($0.current.next,
-                            name: "cursor-id")
-                    {
-                        tests.assert($0.database ==? context.database,
-                            name: "cursor-database-name")
-                        tests.assert($0.collection ==? collection,
-                            name: "cursor-collection-name")
-                        return cursor
-                    }
-                    else
-                    {
-                        return nil
-                    }
-                }
-                guard let cursor:Mongo.CursorIdentifier
-                else
-                {
-                    return
-                }
-
-                let cursors:Mongo.KillCursors.Response = try await session.run(
-                    command: Mongo.KillCursors.init([cursor], 
-                        collection: collection),
-                    against: context.database)
-                // if the cursor is already dead, killing it manually will return 'notFound'.
-                tests.assert(cursors.alive **? [], name: "cursors-alive")
-                tests.assert(cursors.killed **? [], name: "cursors-killed")
-                tests.assert(cursors.unknown **? [], name: "cursors-unknown")
-                tests.assert(cursors.notFound **? [cursor], name: "cursors-not-found")
-            }
-            await tests.test(with: SessionEnvironment.init(name: "connection-multiplexing",
-                pool: context.pool))
-            {
-                (tests:inout Tests, session:Mongo.Session) in
-
-                try await session.run(
-                    query: Mongo.Find<Ordinal>.init(collection: collection, stride: 10),
-                    against: context.database)
-                {
-                    var counter:Int = 0
-                    for try await batch:[Ordinal] in $0
-                    {
-                        let names:[Mongo.Database] = try await context.pool.run(
-                            command: Mongo.ListDatabases.NameOnly.init())
-                        tests.assert(!batch.isEmpty, name: "stream.\(counter)")
-                        tests.assert(!names.isEmpty, name: "list-databases.\(counter)")
-
-                        counter += 1
-                    }
-                }
-            }
+            await TestDatabases(&$0, bootstrap: bootstrap, hosts: [standalone])
+            await TestInsert(&$0, bootstrap: bootstrap, hosts: [standalone])
+            await TestFind(&$0, bootstrap: bootstrap, hosts: [standalone])
+            await TestCursors(&$0, bootstrap: bootstrap, hosts: [standalone])
         }
     }
 }

--- a/Tests/MongoDB/Main.swift
+++ b/Tests/MongoDB/Main.swift
@@ -11,16 +11,15 @@ enum Main:AsyncTests
     {
         let executor:MultiThreadedEventLoopGroup = .init(numberOfThreads: 2)
 
-        let standalone:MongoTopology.Host = .init(name: "mongo-single", port: 27017)
-        let members:Set<MongoTopology.Host> =
-        [
-            .init(name: "mongo-1", port: 27017),
-            .init(name: "mongo-2", port: 27017),
-            .init(name: "mongo-3", port: 27017),
-        ]
-
         await tests.group("replicated-topology")
         {
+            let members:Set<MongoTopology.Host> =
+            [
+                .init(name: "mongo-1", port: 27017),
+                .init(name: "mongo-2", port: 27017),
+                .init(name: "mongo-3", port: 27017),
+            ]
+            
             print("running tests for replicated topology (hosts: \(members))")
 
             let bootstrap:Mongo.DriverBootstrap = .init(
@@ -28,6 +27,7 @@ enum Main:AsyncTests
                 credentials: nil,
                 executor: executor)
 
+            await TestFsync(&$0, bootstrap: bootstrap, hosts: members)
             await TestDatabases(&$0, bootstrap: bootstrap, hosts: members)
             await TestInsert(&$0, bootstrap: bootstrap, hosts: members)
             await TestFind(&$0, bootstrap: bootstrap, hosts: members)
@@ -36,6 +36,8 @@ enum Main:AsyncTests
 
         await tests.group("single-topology")
         {
+            let standalone:MongoTopology.Host = .init(name: "mongo-single", port: 27017)
+
             print("running tests for single topology (host: \(standalone))")
 
             let bootstrap:Mongo.DriverBootstrap = .init(
@@ -45,6 +47,7 @@ enum Main:AsyncTests
                     password: "80085"),
                 executor: executor)
 
+            await TestFsync(&$0, bootstrap: bootstrap, hosts: [standalone])
             await TestDatabases(&$0, bootstrap: bootstrap, hosts: [standalone])
             await TestInsert(&$0, bootstrap: bootstrap, hosts: [standalone])
             await TestFind(&$0, bootstrap: bootstrap, hosts: [standalone])

--- a/Tests/MongoDB/TestCursors.swift
+++ b/Tests/MongoDB/TestCursors.swift
@@ -1,0 +1,121 @@
+import MongoDB
+import MongoTopology
+import Testing
+
+func TestCursors(_ tests:inout Tests,
+    bootstrap:Mongo.DriverBootstrap,
+    hosts:Set<MongoTopology.Host>) async
+{
+    await tests.test(with: DatabaseEnvironment.init(bootstrap: bootstrap,
+        database: "cursors",
+        hosts: hosts))
+    {
+        (tests:inout Tests, context:DatabaseEnvironment.Context) in
+
+        let collection:Mongo.Collection = "ordinals"
+        let ordinals:Ordinals = .init(identifiers: 0 ..< 100)
+
+        await tests.test(name: "initialize")
+        {
+            let expected:Mongo.InsertResponse = .init(inserted: 100)
+            let response:Mongo.InsertResponse = try await context.pool.run(
+                command: Mongo.Insert<Ordinals>.init(collection: collection,
+                    elements: ordinals),
+                against: context.database)
+            
+            $0.assert(response ==? expected, name: "response")
+        }
+        
+        await tests.test(with: SessionEnvironment.init(name: "cursor-cleanup-normal",
+            pool: context.pool))
+        {
+            (tests:inout Tests, session:Mongo.Session) in
+
+            try await session.run(query: Mongo.Find<Ordinal>.init(
+                    collection: collection,
+                    stride: 10),
+                against: context.database)
+            {
+                guard   let cursor:Mongo.CursorIdentifier =
+                            tests.unwrap($0.current.next, name: "cursor-id")
+                else
+                {
+                    return
+                }
+                for try await _:[Ordinal] in $0
+                {
+                }
+                let cursors:Mongo.KillCursors.Response = try await session.run(
+                    command: Mongo.KillCursors.init([cursor], 
+                        collection: $0.collection),
+                    against: $0.database)
+                // if the cursor is already dead, killing it manually will return 'notFound'.
+                tests.assert(cursors.alive **? [], name: "cursors-alive")
+                tests.assert(cursors.killed **? [], name: "cursors-killed")
+                tests.assert(cursors.unknown **? [], name: "cursors-unknown")
+                tests.assert(cursors.notFound **? [cursor], name: "cursors-not-found")
+            }
+        }
+        await tests.test(with: SessionEnvironment.init(name: "cursor-cleanup-interruption",
+            pool: context.pool))
+        {
+            (tests:inout Tests, session:Mongo.Session) in
+
+            let cursor:Mongo.CursorIdentifier? =
+                try await session.run(
+                    query: Mongo.Find<Ordinal>.init(collection: collection, stride: 10),
+                    against: context.database)
+            {
+                if  let cursor:Mongo.CursorIdentifier = tests.unwrap($0.current.next,
+                        name: "cursor-id")
+                {
+                    tests.assert($0.database ==? context.database,
+                        name: "cursor-database-name")
+                    tests.assert($0.collection ==? collection,
+                        name: "cursor-collection-name")
+                    return cursor
+                }
+                else
+                {
+                    return nil
+                }
+            }
+            guard let cursor:Mongo.CursorIdentifier
+            else
+            {
+                return
+            }
+
+            let cursors:Mongo.KillCursors.Response = try await session.run(
+                command: Mongo.KillCursors.init([cursor], 
+                    collection: collection),
+                against: context.database)
+            // if the cursor is already dead, killing it manually will return 'notFound'.
+            tests.assert(cursors.alive **? [], name: "cursors-alive")
+            tests.assert(cursors.killed **? [], name: "cursors-killed")
+            tests.assert(cursors.unknown **? [], name: "cursors-unknown")
+            tests.assert(cursors.notFound **? [cursor], name: "cursors-not-found")
+        }
+        await tests.test(with: SessionEnvironment.init(name: "connection-multiplexing",
+            pool: context.pool))
+        {
+            (tests:inout Tests, session:Mongo.Session) in
+
+            try await session.run(
+                query: Mongo.Find<Ordinal>.init(collection: collection, stride: 10),
+                against: context.database)
+            {
+                var counter:Int = 0
+                for try await batch:[Ordinal] in $0
+                {
+                    let names:[Mongo.Database] = try await context.pool.run(
+                        command: Mongo.ListDatabases.NameOnly.init())
+                    tests.assert(!batch.isEmpty, name: "stream.\(counter)")
+                    tests.assert(!names.isEmpty, name: "list-databases.\(counter)")
+
+                    counter += 1
+                }
+            }
+        }
+    }
+}

--- a/Tests/MongoDB/TestDatabases.swift
+++ b/Tests/MongoDB/TestDatabases.swift
@@ -1,0 +1,40 @@
+import MongoDB
+import MongoTopology
+import Testing
+
+func TestDatabases(_ tests:inout Tests,
+    bootstrap:Mongo.DriverBootstrap,
+    hosts:Set<MongoTopology.Host>) async
+{
+    await tests.test(with: DatabaseEnvironment.init(bootstrap: bootstrap,
+        database: "databases",
+        hosts: hosts))
+    {
+        (tests:inout Tests, context:DatabaseEnvironment.Context) in
+
+        await tests.test(name: "create-database-by-collection")
+        {
+            _ in try await context.pool.run(
+                command: Mongo.Create.init(collection: "placeholder"), 
+                against: context.database)
+        }
+
+        await tests.test(name: "list-database-names")
+        {
+            let names:[Mongo.Database] = try await context.pool.run(
+                command: Mongo.ListDatabases.NameOnly.init())
+            $0.assert(names.contains(context.database),
+                name: "contains")
+        }
+
+        await tests.test(name: "list-databases")
+        {
+            let (size, databases):(Int, [Mongo.DatabaseMetadata]) = try await context.pool.run(
+                command: Mongo.ListDatabases.init())
+            $0.assert(size > 0,
+                name: "nonzero-size")
+            $0.assert(databases.contains { $0.database == context.database },
+                name: "contains")
+        }
+    }
+}

--- a/Tests/MongoDB/TestFind.swift
+++ b/Tests/MongoDB/TestFind.swift
@@ -1,0 +1,99 @@
+import MongoDB
+import MongoTopology
+import Testing
+
+func TestFind(_ tests:inout Tests,
+    bootstrap:Mongo.DriverBootstrap,
+    hosts:Set<MongoTopology.Host>) async
+{
+    await tests.test(with: DatabaseEnvironment.init(bootstrap: bootstrap,
+        database: "collection-find",
+        hosts: hosts))
+    {
+        (tests:inout Tests, context:DatabaseEnvironment.Context) in
+
+        let collection:Mongo.Collection = "ordinals"
+        let ordinals:Ordinals = .init(identifiers: 0 ..< 100)
+
+        await tests.test(name: "initialize")
+        {
+            let expected:Mongo.InsertResponse = .init(inserted: 100)
+            let response:Mongo.InsertResponse = try await context.pool.run(
+                command: Mongo.Insert<Ordinals>.init(collection: collection,
+                    elements: ordinals),
+                against: context.database)
+            
+            $0.assert(response ==? expected, name: "response")
+        }
+        // await tests.test(name: "single-batch")
+        // {
+        //     let expected:Mongo.Cursor<Ordinal> = .init(id: 0,
+        //         namespace: .init(database, collection),
+        //         elements: [Ordinal].init(ordinals.prefix(10)))
+        //     let cursor:Mongo.Cursor<Ordinal> = try await cluster.run(
+        //         command: Mongo.Find<Ordinal>.init(collection: collection,
+        //             returning: .batch(of: 10)),
+        //         against: database)
+
+        //     $0.assert(cursor ==? expected, name: "cursor")
+        // }
+        await tests.test(name: "multiple-batches")
+        {
+            (tests:inout Tests) in
+
+            try await context.pool.withSession
+            {
+                try await $0.run(query: Mongo.Find<Ordinal>.init(
+                        collection: collection,
+                        stride: 10),
+                    against: context.database)
+                {
+                    var expected:Ordinals.Iterator = ordinals.makeIterator()
+                    for try await batch:[Ordinal] in $0
+                    {
+                        for returned:Ordinal in batch
+                        {
+                            if  let expected:Ordinal = tests.unwrap(expected.next(),
+                                    name: "next-expected")
+                            {
+                                tests.assert(returned == expected,
+                                    name: expected.id.description)
+                            }
+                        }
+                    }
+                    tests.assert(expected.next() == nil, name: "next-returned")
+                }
+            }
+        }
+        await tests.test(with: SessionEnvironment.init(name: "filtering",
+            pool: context.pool))
+        {
+            (tests:inout Tests, session:Mongo.Session) in
+        
+            try await session.run(query: Mongo.Find<Ordinal>.init(
+                    collection: collection,
+                    stride: 10,
+                    filter: .init
+                    {
+                        $0["ordinal"] = ["$mod": [3, 0]]
+                    }),
+                against: context.database)
+            {
+                var expected:Array<Ordinal>.Iterator = 
+                    ordinals.filter { $0.value % 3 == 0 }.makeIterator()
+                for try await batch:[Ordinal] in $0
+                {
+                    for returned:Ordinal in batch
+                    {
+                        if  let expected:Ordinal = tests.unwrap(expected.next(),
+                                name: "next-expected")
+                        {
+                            tests.assert(returned == expected, name: expected.id.description)
+                        }
+                    }
+                }
+                tests.assert(expected.next() == nil, name: "next-returned")
+            }
+        }
+    }
+}

--- a/Tests/MongoDB/TestFsync.swift
+++ b/Tests/MongoDB/TestFsync.swift
@@ -1,0 +1,25 @@
+import MongoDB
+import MongoTopology
+import Testing
+
+func TestFsync(_ tests:inout Tests,
+    bootstrap:Mongo.DriverBootstrap,
+    hosts:Set<MongoTopology.Host>) async
+{
+    await tests.test(with: DatabaseEnvironment.init(bootstrap: bootstrap,
+        database: "fsync-locking",
+        hosts: hosts))
+    {
+        (tests:inout Tests, context:DatabaseEnvironment.Context) in
+
+        var lock:Mongo.FsyncLock
+        
+        lock = try await context.pool.run(command: Mongo.Fsync.init(lock: true))
+        
+        tests.assert(lock.count ==? 1, name: "lock-count-locked")
+
+        lock = try await context.pool.run(command: Mongo.FsyncUnlock.init())
+
+        tests.assert(lock.count ==? 0, name: "lock-count-unlocked")
+    }
+}

--- a/Tests/MongoDB/TestInsert.swift
+++ b/Tests/MongoDB/TestInsert.swift
@@ -1,0 +1,103 @@
+import MongoDB
+import MongoTopology
+import Testing
+
+func TestInsert(_ tests:inout Tests,
+    bootstrap:Mongo.DriverBootstrap,
+    hosts:Set<MongoTopology.Host>) async
+{
+    await tests.test(with: DatabaseEnvironment.init(bootstrap: bootstrap,
+        database: "collection-insert",
+        hosts: hosts))
+    {
+        (tests:inout Tests, context:DatabaseEnvironment.Context) in
+
+        let collection:Mongo.Collection = "ordinals"
+
+        await tests.test(name: "insert-one")
+        {
+            let expected:Mongo.InsertResponse = .init(inserted: 1)
+            let response:Mongo.InsertResponse = try await context.pool.run(
+                command: Mongo.Insert<Ordinals>.init(collection: collection,
+                    elements: .init(identifiers: 0 ..< 1)),
+                against: context.database)
+            
+            $0.assert(response ==? expected, name: "response")
+        }
+
+        await tests.test(name: "insert-multiple")
+        {
+            let expected:Mongo.InsertResponse = .init(inserted: 15)
+            let response:Mongo.InsertResponse = try await context.pool.run(
+                command: Mongo.Insert<Ordinals>.init(collection: collection,
+                    elements: .init(identifiers: 1 ..< 16)),
+                against: context.database)
+            
+            $0.assert(response ==? expected, name: "response")
+        }
+
+        await tests.test(name: "insert-duplicate-id")
+        {
+            let expected:Mongo.InsertResponse = .init(inserted: 0,
+                writeErrors:
+                [
+                    .init(index: 0,
+                        message:
+                        """
+                        E11000 duplicate key error collection: \
+                        \(context.database).\(collection) index: _id_ dup key: { _id: 0 }
+                        """,
+                        code: 11000),
+                ])
+            let response:Mongo.InsertResponse = try await context.pool.run(
+                command: Mongo.Insert<Ordinals>.init(collection: collection,
+                    elements: .init(identifiers: 0 ..< 1)),
+                against: context.database)
+            
+            $0.assert(response ==? expected, name: "response")
+        }
+
+        await tests.test(name: "insert-ordered")
+        {
+            let expected:Mongo.InsertResponse = .init(inserted: 8,
+                writeErrors:
+                [
+                    .init(index: 8,
+                        message:
+                        """
+                        E11000 duplicate key error collection: \
+                        \(context.database).\(collection) index: _id_ dup key: { _id: 0 }
+                        """,
+                        code: 11000),
+                ])
+            let response:Mongo.InsertResponse = try await context.pool.run(
+                command: Mongo.Insert<Ordinals>.init(collection: collection,
+                    elements: .init(identifiers: -8 ..< 32)),
+                against: context.database)
+            
+            $0.assert(response ==? expected, name: "response")
+        }
+
+        await tests.test(name: "insert-unordered")
+        {
+            let expected:Mongo.InsertResponse = .init(inserted: 24,
+                writeErrors: (8 ..< 32).map
+                {
+                    .init(index: $0,
+                        message:
+                        """
+                        E11000 duplicate key error collection: \
+                        \(context.database).\(collection) index: _id_ dup key: { _id: \($0 - 16) }
+                        """,
+                        code: 11000)
+                })
+            let response:Mongo.InsertResponse = try await context.pool.run(
+                command: Mongo.Insert<Ordinals>.init(collection: collection,
+                    elements: .init(identifiers: -16 ..< 32),
+                    ordered: false),
+                against: context.database)
+            
+            $0.assert(response ==? expected, name: "response")
+        }
+    }
+}

--- a/Tests/MongoDriver/TestMemberDiscovery.swift
+++ b/Tests/MongoDriver/TestMemberDiscovery.swift
@@ -1,60 +1,64 @@
 import MongoDriver
 import MongoTopology
-import NIOPosix
 import Testing
 
-func TestMemberDiscovery(_ tests:inout Tests, members:[MongoTopology.Host],
-    on executor:MultiThreadedEventLoopGroup) async
+func TestMemberDiscovery(_ tests:inout Tests,
+    bootstrap:Mongo.DriverBootstrap,
+    members:[MongoTopology.Host]) async
 {
     //  we should be able to connect to the primary using any seed
-    await tests.group("seeding")
+    for seed:MongoTopology.Host in members
     {
-        for seed:MongoTopology.Host in members
+        await tests.test(name: "discover-primary-from-\(seed.name)")
         {
-            await $0.test(with: DriverEnvironment.init(
-                name: "discover-primary-from-\(seed.name)",
-                credentials: nil,
-                executor: executor))
+            (tests:inout Tests) in
+
+            try await bootstrap.withSessionPool(seedlist: [seed])
             {
-                (tests:inout Tests, bootstrap:Mongo.DriverBootstrap) in
-
-                try await bootstrap.withSessionPool(seedlist: [seed])
+                try await $0.withSession(connectionTimeout: .seconds(3))
                 {
-                    try await $0.withSession(connectionTimeout: .seconds(5))
-                    {
-                        let configuration:Mongo.ReplicaSetConfiguration = try await $0.run(
-                            command: Mongo.ReplicaSetGetConfiguration.init(),
-                            on: .primary)
-                        //  this was the configuration we initialized the test set with:
-                        //  (/.github/mongonet/create-replica-set.js)
+                    let configuration:Mongo.ReplicaSetConfiguration = try await $0.run(
+                        command: Mongo.ReplicaSetGetConfiguration.init(),
+                        on: .primary)
+                    //  this was the configuration we initialized the test set with:
+                    //  (/.github/mongonet/create-replica-set.js)
 
-                        //  we can’t assert the configuration as a whole, because the
-                        //  term will increment on its own.
-                        tests.assert(configuration.name ==? "test-set",
-                            name: "configuration-name")
-                        
-                        tests.assert(configuration.writeConcernMajorityJournalDefault ==? true,
-                            name: "configuration-journaling")
-                        
-                        tests.assert(configuration.members ..?
-                            [
-                                .init(id: 1, host: members[0], replica: .init(
-                                    rights: .init(priority: 2.0),
-                                    votes: 1,
-                                    tags: ["c": "C", "a": "A", "b": "B"])),
-                                
-                                .init(id: 2, host: members[1], replica: .init(
-                                    rights: .init(priority: 1.0),
-                                    votes: 1,
-                                    tags: ["b": "B", "d": "D", "c": "C"])),
-                                
-                                .init(id: 3, host: members[2], replica: nil),
-                            ],
-                            name: "configuration-members")
-                        
-                        tests.assert(configuration.version ==? 1,
-                            name: "configuration-version")
-                    }
+                    //  we can’t assert the configuration as a whole, because the
+                    //  term will increment on its own.
+                    tests.assert(configuration.name ==? "test-set",
+                        name: "configuration-name")
+                    
+                    tests.assert(configuration.writeConcernMajorityJournalDefault ==? true,
+                        name: "configuration-journaling")
+                    
+                    tests.assert(configuration.members ..?
+                        [
+                            .init(id: 0, host: members[0], replica: .init(
+                                rights: .init(priority: 2.0),
+                                votes: 1,
+                                tags: ["priority": "high", "name": "A"])),
+                            
+                            .init(id: 1, host: members[1], replica: .init(
+                                rights: .init(priority: 1.0),
+                                votes: 1,
+                                tags: ["priority": "low", "name": "B"])),
+                            
+                            .init(id: 2, host: members[2], replica: .init(
+                                rights: .resident,
+                                votes: 1,
+                                tags: ["priority": "zero", "name": "C"])),
+                            
+                            .init(id: 3, host: members[3], replica: .init(
+                                rights: .resident(.init(buildsIndexes: true, delay: 5)),
+                                votes: 0,
+                                tags: ["priority": "zero", "name": "H"])),
+                            
+                            .init(id: 4, host: members[4], replica: nil),
+                        ],
+                        name: "configuration-members")
+                    
+                    tests.assert(configuration.version ==? 1,
+                        name: "configuration-version")
                 }
             }
         }

--- a/Tests/MongoDriver/TestReadPreference.swift
+++ b/Tests/MongoDriver/TestReadPreference.swift
@@ -1,0 +1,199 @@
+import MongoDriver
+import MongoTopology
+import Testing
+
+func TestReadPreference(_ tests:inout Tests,
+    bootstrap:Mongo.DriverBootstrap,
+    members:[MongoTopology.Host]) async
+{
+    await tests.test(name: "read-preferences")
+    {
+        (tests:inout Tests) in
+
+        try await bootstrap.withSessionPool(seedlist: .init(members))
+        {
+            try await $0.withSession(connectionTimeout: .milliseconds(250))
+            {
+                (session:Mongo.Session) in
+
+                for (name, preference):(String, Mongo.ReadPreference) in
+                [
+                    (
+                        "primary",
+                        .primary
+                    ),
+                    (
+                        "primary-preferred",
+                        .primaryPreferred
+                    ),
+                    //  We should be able to select the primary regardless
+                    //  of tag sets.
+                    (
+                        "primary-preferred-tagged",
+                        .primaryPreferred(.init(maxStaleness: nil,
+                            tagSets: [["name": "A", "priority": "high"]]))
+                    ),
+                    //  We should be able to select the primary even if
+                    //  none of the tags match.
+                    (
+                        "primary-preferred-no-matches",
+                        .primaryPreferred(.init(maxStaleness: nil,
+                            tagSets: [["name": "Z"]]))
+                    ),
+                    //  We should be able to select any replica with nearest
+                    //  read preference.
+                    (
+                        "nearest",
+                        .nearest
+                    ),
+                    //  An empty tag set list should behave the same as no
+                    //  tag set list.
+                    (
+                        "nearest-empty-tag-set-list",
+                        .nearest(.init(maxStaleness: nil, tagSets: []))
+                    ),
+                    //  A tag set list with a single, empty tag set should
+                    //  behave the same as no tag set list.
+                    (
+                        "nearest-empty-tag-set",
+                        .nearest(.init(maxStaleness: nil, tagSets: [[:]]))
+                    ),
+                    //  A tag set list with many empty tag sets should
+                    //  behave the same as no tag set list.
+                    (
+                        "nearest-empty-tag-sets",
+                        .nearest(.init(maxStaleness: nil, tagSets: [[:], [:]]))
+                    ),
+                    //  We should be able to select a replica by specifying
+                    //  all of its tags.
+                    (
+                        "nearest-tagged",
+                        .nearest(.init(maxStaleness: nil,
+                            tagSets: [["name": "A", "priority": "high"]]))
+                    ),
+                    //  We should be able to select a replica by specifying
+                    //  some of its tags.
+                    (
+                        "nearest-tagged-name-A",
+                        .nearest(.init(maxStaleness: nil,
+                            tagSets: [["name": "A"]]))
+                    ),
+                    //  Moreover, all non-hidden replicas should qualify for
+                    //  nearest read preference.
+                    (
+                        "nearest-tagged-name-B",
+                        .nearest(.init(maxStaleness: nil,
+                            tagSets: [["name": "B"]]))
+                    ),
+                    (
+                        "nearest-tagged-name-C",
+                        .nearest(.init(maxStaleness: nil,
+                            tagSets: [["name": "C"]]))
+                    ),
+                    //  A secondary should qualify for nearest read preference.
+                    (
+                        "nearest-tagged-priority-zero",
+                        .nearest(.init(maxStaleness: nil,
+                            tagSets: [["priority": "zero"]]))
+                    ),
+                    //  If we use a maximum staleness of zero, we should still be
+                    //  able to select the primary. (Because the primary has
+                    //  zero staleness by definition.)
+                    (
+                        "nearest-staleness-zero",
+                        .nearest(.init(maxStaleness: 0, tagSets: nil))
+                    ),
+                    //  We should be able to select any replica with
+                    //  secondary-preferred read preference.
+                    (
+                        "secondary-preferred",
+                        .secondaryPreferred
+                    ),
+                    //  We should be able to select the primary even if
+                    //  none of the tags match.
+                    (
+                        "secondary-preferred-no-matches",
+                        .primaryPreferred(.init(maxStaleness: nil,
+                            tagSets: [["name": "Z"]]))
+                    ),
+                    //  A secondary should qualify for secondary-preferred
+                    //  read preference.
+                    (
+                        "secondary-preferred-priority-zero",
+                        .secondaryPreferred(.init(maxStaleness: nil,
+                            tagSets: [["priority": "zero"]]))
+                    ),
+                    //  We should be able to select a member by tag sets
+                    //  as long as one set matches.
+                    (
+                        "secondary-preferred-multiple-tag-sets",
+                        .secondaryPreferred(.init(maxStaleness: nil,
+                            tagSets: [["name": "Z"], ["priority": "zero"]]))
+                    ),
+                    //  It follows that we should be able to select a member
+                    //  by tag sets as long as one set is empty.
+                    (
+                        "secondary-preferred-multiple-tag-sets",
+                        .secondaryPreferred(.init(maxStaleness: nil,
+                            tagSets: [["name": "Z"], [:]]))
+                    ),
+                    //  We should be able to select any secondary with
+                    //  secondary read preference.
+                    (
+                        "secondary",
+                        .secondary
+                    ),
+                ]
+                {
+                    await tests.test(name: name)
+                    {
+                        _ in try await session.run(
+                            command: Mongo.RefreshSessions.init(session.id),
+                            on: preference)
+                    }
+                }
+
+                for (name, preference):(String, Mongo.ReadPreference) in
+                [
+                    //  We should not be able to select the primary with
+                    //  nearest read preference if none of the tags match.
+                    //  (Because eligibility applies to the primary.)
+                    (
+                        "nearest-no-matches",
+                        .nearest(.init(maxStaleness: nil,
+                            tagSets: [["name": "Z"]]))
+                    ),
+                    //  We should not be able to select a member if any of
+                    //  the tag set patterns do not match, even if some of
+                    //  them do match.
+                    (
+                        "nearest-partial-match",
+                        .nearest(.init(maxStaleness: nil,
+                            tagSets: [["name": "A", "priority": "bananas"]]))
+                    ),
+                ]
+                {
+                    await tests.test(name: name,
+                        expecting: Mongo.ClusterError<Mongo.ReadPreferenceError>.init(
+                            diagnostics: .init(
+                                undesirable:
+                                [
+                                    members[4]: .arbiter,
+                                ],
+                                unsuitable:
+                                [
+                                    members[0]: .tags(["name": "A", "priority": "high"]),
+                                    members[1]: .tags(["name": "B", "priority": "low"]),
+                                    members[2]: .tags(["name": "C", "priority": "zero"]),
+                                ]),
+                            failure: .init(preference: preference)))
+                    {
+                        _ in try await session.run(
+                            command: Mongo.RefreshSessions.init(session.id),
+                            on: preference)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/MongoDriver/TestSessionPool.swift
+++ b/Tests/MongoDriver/TestSessionPool.swift
@@ -127,4 +127,57 @@ func TestSessionPool(_ tests:inout Tests,
             }
         }
     }
+    await tests.group("sessions")
+    {
+        /// Two non-overlapping sessions should re-use the same session.
+        await $0.test(with: DriverEnvironment.init(name: "non-overlapping",
+            credentials: credentials, executor: executor))
+        {
+            (tests:inout Tests, bootstrap:Mongo.DriverBootstrap) in
+
+            try await bootstrap.withSessionPool(seedlist: seedlist)
+            {
+                let id:(Mongo.SessionIdentifier, Mongo.SessionIdentifier)
+
+                id.0 = try await $0.withSession
+                {
+                    try await $0.run(command: Mongo.RefreshSessions.init($0.id))
+                    return $0.id
+                }
+                id.1 = try await $0.withSession
+                {
+                    try await $0.run(command: Mongo.RefreshSessions.init($0.id))
+                    return $0.id
+                }
+
+                tests.assert(id.0 ==? id.1, name: "identifiers-equal")
+            }
+        }
+        /// Two overlapping sessions should not re-use the same session.
+        await $0.test(with: DriverEnvironment.init(name: "overlapping",
+            credentials: credentials, executor: executor))
+        {
+            (tests:inout Tests, bootstrap:Mongo.DriverBootstrap) in
+
+            try await bootstrap.withSessionPool(seedlist: seedlist)
+            {
+                (pool:Mongo.SessionPool) in 
+
+                let id:(Mongo.SessionIdentifier, Mongo.SessionIdentifier) =
+                    try await pool.withSession
+                {
+                    try await $0.run(command: Mongo.RefreshSessions.init($0.id))
+
+                    let id:Mongo.SessionIdentifier = try await pool.withSession
+                    {
+                        try await $0.run(command: Mongo.RefreshSessions.init($0.id))
+                        return $0.id
+                    }
+                    return ($0.id, id)
+                }
+
+                tests.assert(id.0 != id.1, name: "identifiers-not-equal")
+            }
+        }
+    }
 }


### PR DESCRIPTION
- adds support for `Mongo.Fsync` and `Mongo.FsyncUnlock`
- adds tests for the fsync commands
- adds tests for session allocation
- makes the mock replica set more realistic:
    - adds a delayed member to the mock replica set
    - adds a non-citizen replica to the mock replica set
- adds many read preference tests