### PR TITLE
maintain a per-session notarized ClusterTime, and max it with the glo…

### DIFF
--- a/Sources/MongoDriver/Commands/Mongo.Reply.swift
+++ b/Sources/MongoDriver/Commands/Mongo.Reply.swift
@@ -12,13 +12,13 @@ extension Mongo
             Mongo.ServerError>
 
         @usableFromInline
-        let operationTime:Instant?
+        let operationTime:Timestamp?
         @usableFromInline
         let clusterTime:ClusterTime?
 
         init(result:Result<BSON.DocumentDecoder<BSON.Key, ByteBufferView>,
                 Mongo.ServerError>,
-            operationTime:Instant?,
+            operationTime:Timestamp?,
             clusterTime:ClusterTime?)
         {
             self.result = result
@@ -69,8 +69,8 @@ extension Mongo.Reply
         let status:Status = try bson["ok"].decode(
             to: Status.self)
 
-        let operationTime:Mongo.Instant? = try bson["operationTime"]?.decode(
-            to: Mongo.Instant.self)
+        let operationTime:Mongo.Timestamp? = try bson["operationTime"]?.decode(
+            to: Mongo.Timestamp.self)
         let clusterTime:Mongo.ClusterTime? = try bson["$clusterTime"]?.decode(
             to: Mongo.ClusterTime.self)
         

--- a/Sources/MongoDriver/Commands/Mongo.Timestamp.swift
+++ b/Sources/MongoDriver/Commands/Mongo.Timestamp.swift
@@ -15,7 +15,7 @@ extension Mongo
     /// duration. MongoDB timestamps can only be compared for
     /// ordering or equality.
     @frozen public
-    struct Instant:Hashable, Sendable
+    struct Timestamp:Hashable, Sendable
     {
         /// The raw BSON timestamp value.
         public
@@ -28,7 +28,7 @@ extension Mongo
         }
     }
 }
-extension Mongo.Instant:Comparable
+extension Mongo.Timestamp:MongoInstant, Comparable
 {
     @inlinable public static
     func < (lhs:Self, rhs:Self) -> Bool
@@ -36,7 +36,7 @@ extension Mongo.Instant:Comparable
         lhs.timestamp < rhs.timestamp
     }
 }
-extension Mongo.Instant:BSONDecodable
+extension Mongo.Timestamp:BSONDecodable
 {
     /// Attempts to cast a BSON variant backed by some storage type to a
     /// MongoDB timestamp. The conversion is not a integer case, and will
@@ -57,7 +57,7 @@ extension Mongo.Instant:BSONDecodable
         })
     }
 }
-extension Mongo.Instant:BSONEncodable
+extension Mongo.Timestamp:BSONEncodable
 {
     /// Encodes this timestamp as a ``BSON.uint64``.
     @inlinable public
@@ -66,7 +66,7 @@ extension Mongo.Instant:BSONEncodable
         field.encode(uint64: self.timestamp)
     }
 }
-extension Mongo.Instant:CustomStringConvertible
+extension Mongo.Timestamp:CustomStringConvertible
 {
     public
     var description:String

--- a/Sources/MongoDriver/ReadConcern/Mongo.ReadConcern.Options.swift
+++ b/Sources/MongoDriver/ReadConcern/Mongo.ReadConcern.Options.swift
@@ -17,12 +17,12 @@ extension Mongo.ReadConcern
 }
 extension Mongo.ReadConcern.Options
 {
-    init(level:Mongo.ReadConcern.Level?, after clusterTime:Mongo.Instant?)
+    init(level:Mongo.ReadConcern.Level?, after clusterTime:Mongo.Timestamp?)
     {
         self.init(ordering: clusterTime.map(Mongo.ReadConcern.Ordering.after(_:)),
             level: level)
     }
-    init(level:Mongo.ReadConcern.Level?, at clusterTime:Mongo.Instant?)
+    init(level:Mongo.ReadConcern.Level?, at clusterTime:Mongo.Timestamp?)
     {
         self.init(ordering: clusterTime.map(Mongo.ReadConcern.Ordering.at(_:)),
             level: level)

--- a/Sources/MongoDriver/ReadConcern/Mongo.ReadConcern.Ordering.swift
+++ b/Sources/MongoDriver/ReadConcern/Mongo.ReadConcern.Ordering.swift
@@ -2,7 +2,7 @@ extension Mongo.ReadConcern
 {
     enum Ordering:Sendable
     {
-        case after(Mongo.Instant)
-        case at(Mongo.Instant)
+        case after(Mongo.Timestamp)
+        case at(Mongo.Timestamp)
     }
 }

--- a/Sources/MongoDriver/Sessions/Mongo.SnapshotSession.swift
+++ b/Sources/MongoDriver/Sessions/Mongo.SnapshotSession.swift
@@ -4,7 +4,7 @@ extension Mongo
     class SnapshotSession:Identifiable
     {
         public private(set)
-        var snapshotTime:Mongo.Instant
+        var snapshotTime:Timestamp
         public private(set)
         var transaction:TransactionState
         private
@@ -21,7 +21,7 @@ extension Mongo
         let pool:SessionPool
 
         private
-        init(snapshotTime:Mongo.Instant, allocation:SessionPool.Allocation, pool:SessionPool)
+        init(snapshotTime:Timestamp, allocation:SessionPool.Allocation, pool:SessionPool)
         {
             self.snapshotTime = snapshotTime
             self.transaction = allocation.transaction

--- a/Sources/MongoDriver/Sessions/MongoInstant.swift
+++ b/Sources/MongoDriver/Sessions/MongoInstant.swift
@@ -1,0 +1,47 @@
+protocol MongoInstant
+{
+    static
+    func < (lhs:Self, rhs:Self) -> Bool
+}
+extension MongoInstant
+{
+    //  Writing this function in terms of ``AtomicState<Self>`` prevents us
+    //  from allocating a new object in the common case where the
+    //  max cluster time has not changed.
+    func combined(with other:Mongo.AtomicState<Self>?) -> Mongo.AtomicState<Self>
+    {
+        guard let other:Mongo.AtomicState<Self>
+        else
+        {
+            return .init(self)
+        }
+        if  other.value < self
+        {
+            return .init(self)
+        }
+        else
+        {
+            return other
+        }
+    }
+    func combined(with other:Self?) -> Self
+    {
+        guard let other:Self
+        else
+        {
+            return self
+        }
+        if  other < self
+        {
+            return self
+        }
+        else
+        {
+            return other
+        }
+    }
+    func combine(into value:inout Self?)
+    {
+        value = self.combined(with: value)
+    }
+}

--- a/Sources/MongoDriver/Transactions/Mongo.Transaction.swift
+++ b/Sources/MongoDriver/Transactions/Mongo.Transaction.swift
@@ -33,7 +33,7 @@ extension Mongo.Transaction
 extension Mongo.Transaction
 {
     @inlinable public
-    var preconditionTime:Mongo.Instant?
+    var preconditionTime:Mongo.Timestamp?
     {
         self.session.preconditionTime
     }

--- a/Tests/MongoDB/TestCausalConsistency.swift
+++ b/Tests/MongoDB/TestCausalConsistency.swift
@@ -48,7 +48,7 @@ func TestCausalConsistency(_ tests:TestGroup,
 
         //  We should be able to observe a precondition time after performing the
         //  initialization.
-        guard var head:Mongo.Instant = tests.expect(value: session.preconditionTime)
+        guard var head:Mongo.Timestamp = tests.expect(value: session.preconditionTime)
         else
         {
             return
@@ -115,7 +115,7 @@ func TestCausalConsistency(_ tests:TestGroup,
         //  We should still be able to observe a precondition time, and the
         //  value of that time should be greater than it was before we inserted
         //  the letter `b` into the collection.
-        if let time:Mongo.Instant = tests.expect(value: session.preconditionTime)
+        if let time:Mongo.Timestamp = tests.expect(value: session.preconditionTime)
         {
             tests.expect(true: head < time)
             head = time
@@ -137,7 +137,7 @@ func TestCausalConsistency(_ tests:TestGroup,
             tests.expect(response ==? .init(inserted: 1))
         }
 
-        if let time:Mongo.Instant = tests.expect(value: session.preconditionTime)
+        if let time:Mongo.Timestamp = tests.expect(value: session.preconditionTime)
         {
             tests.expect(true: head < time)
             head = time
@@ -160,7 +160,7 @@ func TestCausalConsistency(_ tests:TestGroup,
             tests.expect(response ==? .init(inserted: 1))
         }
 
-        if let time:Mongo.Instant = tests.expect(value: session.preconditionTime)
+        if let time:Mongo.Timestamp = tests.expect(value: session.preconditionTime)
         {
             tests.expect(true: head < time)
             head = time
@@ -244,7 +244,7 @@ func TestCausalConsistency(_ tests:TestGroup,
                 against: database,
                 on: secondary)
             
-            guard let time:Mongo.Instant = tests.expect(value: other.preconditionTime)
+            guard let time:Mongo.Timestamp = tests.expect(value: other.preconditionTime)
             else
             {
                 return

--- a/Tests/MongoDB/TestTransactions.swift
+++ b/Tests/MongoDB/TestTransactions.swift
@@ -72,7 +72,7 @@ func TestTransactions(_ tests:TestGroup,
                 //  We should be able to observe a precondition time associated with
                 //  this transaction, because we have used its underlying session
                 //  before.
-                let _:Mongo.Instant? = tests.expect(value: transaction.preconditionTime)
+                let _:Mongo.Timestamp? = tests.expect(value: transaction.preconditionTime)
                 //  We should be able to start a transaction with a write command,
                 //  even though it also has a non-[`nil`]() precondition time.
                 await (tests / "insert").do

--- a/Tests/MongoDriver/TestSessionPool.swift
+++ b/Tests/MongoDriver/TestSessionPool.swift
@@ -131,7 +131,7 @@ func TestSessionPool(_ tests:TestGroup,
 
                 if seedlist.count > 1
                 {
-                    let _:Mongo.Instant? = tests.expect(value: b.preconditionTime)
+                    let _:Mongo.Timestamp? = tests.expect(value: b.preconditionTime)
                 }
 
                 try await a.refresh()


### PR DESCRIPTION
…bal atomic time, to ensure we are less likely to send an operationTime greater than an associated